### PR TITLE
Fix typo, and delete trailing spaces 

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -79,7 +79,7 @@ virsh start ocp4-aHelper
 
 ## Create "empty" VMs
 
-Create (but do NOT install) 6 empty VMs. Please follow the [min requirements](https://docs.openshift.com/container-platform/4.2/installing/installing_bare_metal/installing-bare-metal.html#minimum-resource-requirements_installing-bare-metal) for these VMs. 
+Create (but do NOT install) 6 empty VMs. Please follow the [min requirements](https://docs.openshift.com/container-platform/4.2/installing/installing_bare_metal/installing-bare-metal.html#minimum-resource-requirements_installing-bare-metal) for these VMs.
 
 > Make sure you attached these to the `openshift4` network!
 
@@ -89,7 +89,7 @@ Create the master VMs
 
 ```
 for i in master{0..2}
-do 
+do
   virt-install --name="ocp4-${i}" --vcpus=4 --ram=12288 \
   --disk path=/var/lib/libvirt/images/ocp4-${i}.qcow2,bus=virtio,size=120 \
   --os-variant rhel8.0 --network network=openshift4,model=virtio \
@@ -104,7 +104,7 @@ Create the bootstrap and worker VMs
 
 ```
 for i in worker{0..1} bootstrap
-do 
+do
   virt-install --name="ocp4-${i}" --vcpus=4 --ram=8192 \
   --disk path=/var/lib/libvirt/images/ocp4-${i}.qcow2,bus=virtio,size=120 \
   --os-variant rhel8.0 --network network=openshift4,model=virtio \
@@ -128,12 +128,8 @@ Install `ansible` and `git` and clone this repo
 ```
 yum -y install ansible git
 git clone https://github.com/RedHatOfficial/ocp4-helpernode
-cd ocp4-upi-helpernode
+cd ocp4-helpernode
 ```
-
-Edit the [vars.yaml](examples/vars.yaml) file with the mac addresses of the "blank" VMs.
-
-> **NOTE** See the `vars.yaml` [documentaion page](vars-doc.md) for more info about what it does.
 
 Get the Mac addresses with this command running from your hypervisor host:
 
@@ -143,6 +139,10 @@ do
   echo -ne "${i}\t" ; virsh dumpxml ocp4-${i} | grep "mac address" | cut -d\' -f2
 done
 ```
+
+Edit the [vars.yaml](examples/vars.yaml) file with the mac addresses of the "blank" VMs.
+
+> **NOTE** See the `vars.yaml` [documentaion page](vars-doc.md) for more info about what it does.
 
 ## Run the playbook
 
@@ -253,7 +253,7 @@ Boot/install the VMs in the following order
 * Masters
 * Workers
 
-On your laptop/workstation visit the status page 
+On your laptop/workstation visit the status page
 
 ```
 firefox http://192.168.7.77:9000
@@ -272,12 +272,12 @@ openshift-install wait-for bootstrap-complete --log-level debug
 Once you see this message below...
 
 ```
-DEBUG OpenShift Installer v4.2.0-201905212232-dirty 
-DEBUG Built from commit 71d8978039726046929729ad15302973e3da18ce 
-INFO Waiting up to 30m0s for the Kubernetes API at https://api.ocp4.example.com:6443... 
-INFO API v1.13.4+838b4fa up                       
-INFO Waiting up to 30m0s for bootstrapping to complete... 
-DEBUG Bootstrap status: complete                   
+DEBUG OpenShift Installer v4.2.0-201905212232-dirty
+DEBUG Built from commit 71d8978039726046929729ad15302973e3da18ce
+INFO Waiting up to 30m0s for the Kubernetes API at https://api.ocp4.example.com:6443...
+INFO API v1.13.4+838b4fa up
+INFO Waiting up to 30m0s for bootstrapping to complete...
+DEBUG Bootstrap status: complete
 INFO It is now safe to remove the bootstrap resources
 ```
 
@@ -335,7 +335,7 @@ oc get csr | grep 'system:node'
 Once Approved; finish up the install process
 
 ```
-openshift-install wait-for install-complete 
+openshift-install wait-for install-complete
 ```
 
 ## Upgrade

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -140,9 +140,13 @@ do
 done
 ```
 
+```
+cp docs/examples/vars.yaml .
+```
+
 Edit the [vars.yaml](examples/vars.yaml) file with the mac addresses of the "blank" VMs.
 
-> **NOTE** See the `vars.yaml` [documentaion page](vars-doc.md) for more info about what it does.
+> **NOTE** See the `vars.yaml` [documentation page](vars-doc.md) for more info about what it does.
 
 ## Run the playbook
 


### PR DESCRIPTION
Fix changedir to current one (after move from the original repo).
Delete trailing spaces in the doc
Order in obtain the macaddresses, because needs to be checked before edit the vars.yml