### PR TITLE
RFE: Create ssh-keys #4

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 # defaults file for tester
+ssh: False

--- a/tasks/generate_ssh_keys.yaml
+++ b/tasks/generate_ssh_keys.yaml
@@ -1,0 +1,19 @@
+---
+- file:
+    path: ~/.ssh
+    state: directory
+    mode: 0700
+
+- openssh_keypair:
+    path: ~/.ssh/id_ssh_ocp4_rsa
+
+- lineinfile:
+    path: ~/.ssh/config
+    line: "{{ item.line }}"
+    state: present
+    backup: yes
+    create: yes
+  with_items:
+    - { line: "Host *.{{ dns.clusterid }}.{{ dns.domain }}" }
+    - { line: "    User core" }
+    - { line: "    IdentityFile ~/.ssh/id_ssh_ocp4_rsa" }

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,11 @@
   handlers:
   - import_tasks: ../handlers/main.yml
   tasks:
+  - name: generate ssh keys
+    import_tasks: generate_ssh_keys.yaml
+    when: ssh
+    tags: test
+
   - name: set setup facts
     include: set_facts_.yaml
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,7 +10,6 @@
   - name: generate ssh keys
     import_tasks: generate_ssh_keys.yaml
     when: ssh
-    tags: test
 
   - name: set setup facts
     include: set_facts_.yaml

--- a/tasks/set_facts_.yaml
+++ b/tasks/set_facts_.yaml
@@ -1,74 +1,70 @@
 ---
-- set_fact:
-    packages:
-      - bind
-      - bind-utils
-      - firewalld
-      - haproxy
-      - httpd
-      - vim
-      - bash-completion
-      - libselinux-python
-      - podman
-      - nfs-utils
+- block:
+  - set_fact:
+      packages:
+        - bind
+        - bind-utils
+        - firewalld
+        - haproxy
+        - httpd
+        - vim
+        - bash-completion
+        - libselinux-python
+        - podman
+        - nfs-utils
+  
+  - set_fact:
+      dhcppkgs:
+        - dhcp
+        - syslinux
+        - tftp-server
+  
+  - set_fact:
+      owner: nobody
+      group: nobody
+  
+  - set_fact:
+      services:
+        - named
+        - haproxy
+        - httpd
+        - rpcbind
+        - nfs-server
+        - nfs-lock
+        - nfs-idmap
   when: ansible_distribution_major_version == "7"
 
-- set_fact:
-    dhcppkgs:
-      - dhcp
-      - syslinux
-      - tftp-server
-  when: ansible_distribution_major_version == "7"
-
-- set_fact:
-    owner: nobody
-    group: nobody
-  when: ansible_distribution_major_version == "7"
-
-- set_fact:
-    services:
-      - named
-      - haproxy
-      - httpd
-      - rpcbind
-      - nfs-server
-      - nfs-lock
-      - nfs-idmap
-  when: ansible_distribution_major_version == "7"
-
-- set_fact:
-    packages:
-      - bind
-      - bind-utils
-      - firewalld
-      - haproxy
-      - httpd
-      - vim
-      - bash-completion
-      - python3-libselinux
-      - podman
-      - nfs-utils
-  when: ansible_distribution_major_version == "8"
-
-- set_fact:
-    dhcppkgs:
-      - dhcp-server
-      - syslinux
-      - tftp-server
-  when: ansible_distribution_major_version == "8"
-
-# See Fedora Wiki for changes:
-# https://fedoraproject.org/wiki/Changes/RenameNobodyUser
-- set_fact:
-    owner: nobody
-    group: nobody
-  when: ansible_distribution_major_version == "8"
-
-- set_fact:
-    services:
-      - named
-      - haproxy
-      - httpd
-      - rpcbind
-      - nfs-server
+- block:
+  - set_fact:
+      packages:
+        - bind
+        - bind-utils
+        - firewalld
+        - haproxy
+        - httpd
+        - vim
+        - bash-completion
+        - python3-libselinux
+        - podman
+        - nfs-utils
+  
+  - set_fact:
+      dhcppkgs:
+        - dhcp-server
+        - syslinux
+        - tftp-server
+  
+  # See Fedora Wiki for changes:
+  # https://fedoraproject.org/wiki/Changes/RenameNobodyUser
+  - set_fact:
+      owner: nobody
+      group: nobody
+  
+  - set_fact:
+      services:
+        - named
+        - haproxy
+        - httpd
+        - rpcbind
+        - nfs-server
   when: ansible_distribution_major_version == "8"


### PR DESCRIPTION
Task takes the following steps assuming there may already be an `id_rsa` key:
- creates .ssh directory if missing
- generates priv/pub keys (can rename key to `helper_rsa`)
- creates ssh config (optional)
  - user connects to cluster nodes using FQDN
  - user connects to cluster nodes as user `core`
- Updated set_facts.yaml to use `Blocks`

Example: `ansible-playbook -e @vars.yaml -e ssh=True tasks/main.yml ` (can add ssh=True to vars.yaml)

OS: `Red Hat Enterprise Linux release 8.1 (Ootpa)`
Ansible: `v2.9.6`