### PR TITLE
RFE: Create ssh-keys

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 # defaults file for tester
+ssh: False

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 # defaults file for tester
-ssh: False
+ssh_gen_key: False

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,2 @@
 ---
-# defaults file for tester
-ssh_gen_key: False
+# defaults file

--- a/docs/examples/vars.yaml
+++ b/docs/examples/vars.yaml
@@ -1,4 +1,5 @@
 ---
+ssh_gen_key: False
 disk: vda
 helper:
   name: "helper"

--- a/docs/examples/vars.yaml
+++ b/docs/examples/vars.yaml
@@ -1,5 +1,4 @@
 ---
-ssh_gen_key: False
 disk: vda
 helper:
   name: "helper"

--- a/tasks/generate_ssh_keys.yaml
+++ b/tasks/generate_ssh_keys.yaml
@@ -1,0 +1,19 @@
+---
+- file:
+    path: ~/.ssh
+    state: directory
+    mode: 0700
+
+- openssh_keypair:
+    path: ~/.ssh/id_ssh_ocp4_rsa
+
+- lineinfile:
+    path: ~/.ssh/config
+    line: "{{ item.line }}"
+    state: present
+    backup: yes
+    create: yes
+  with_items:
+    - { line: "Host *.{{ dns.clusterid }}.{{ dns.domain }}" }
+    - { line: "    User core" }
+    - { line: "    IdentityFile ~/.ssh/id_ssh_ocp4_rsa" }

--- a/tasks/generate_ssh_keys.yaml
+++ b/tasks/generate_ssh_keys.yaml
@@ -5,7 +5,10 @@
     mode: 0700
 
 - openssh_keypair:
-    path: ~/.ssh/id_ssh_ocp4_rsa
+   path: ~/.ssh/helper_rsa
+   size: 4096
+   comment: "{{ ansible_env.USER }}@helper"
+   state: present
 
 - lineinfile:
     path: ~/.ssh/config
@@ -14,6 +17,7 @@
     backup: yes
     create: yes
   with_items:
-    - { line: "Host *.{{ dns.clusterid }}.{{ dns.domain }}" }
+    - { line: "Host *" }
+    - { line: "    HostName %h.{{ dns.clusterid }}.{{ dns.domain }}" }
     - { line: "    User core" }
-    - { line: "    IdentityFile ~/.ssh/id_ssh_ocp4_rsa" }
+    - { line: "    IdentityFile ~/.ssh/helper_rsa" }

--- a/tasks/generate_ssh_keys.yaml
+++ b/tasks/generate_ssh_keys.yaml
@@ -1,17 +1,17 @@
 ---
 - file:
-    path: ~/.ssh
+    path: "{{ ansible_env.HOME }}/.ssh"
     state: directory
     mode: 0700
 
 - openssh_keypair:
-   path: ~/.ssh/helper_rsa
+   path: "{{ ansible_env.HOME }}/.ssh/helper_rsa"
    size: 4096
    comment: "{{ ansible_env.USER }}@helper"
    state: present
 
 - lineinfile:
-    path: ~/.ssh/config
+    path: "{{ ansible_env.HOME }}/.ssh/config"
     line: "{{ item.line }}"
     state: present
     backup: yes
@@ -20,4 +20,4 @@
     - { line: "Host *" }
     - { line: "    HostName %h.{{ dns.clusterid }}.{{ dns.domain }}" }
     - { line: "    User core" }
-    - { line: "    IdentityFile ~/.ssh/helper_rsa" }
+    - { line: "    IdentityFile {{ ansible_env.HOME }}/.ssh/helper_rsa" }

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,11 @@
   handlers:
   - import_tasks: ../handlers/main.yml
   tasks:
+  - name: generate ssh keys
+    import_tasks: generate_ssh_keys.yaml
+    when: ssh
+    tags: test
+
   - name: set setup facts
     include: set_facts_.yaml
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,7 +10,6 @@
   - name: generate ssh keys
     import_tasks: generate_ssh_keys.yaml
     when: ssh
-    tags: test
 
   - name: set setup facts
     include: set_facts_.yaml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,10 +6,11 @@
     - ../vars/main.yml
   handlers:
   - import_tasks: ../handlers/main.yml
+
   tasks:
   - name: generate ssh keys
     import_tasks: generate_ssh_keys.yaml
-    when: ssh
+    when: ssh_gen_key
 
   - name: set setup facts
     include: set_facts_.yaml

--- a/tasks/set_facts_.yaml
+++ b/tasks/set_facts_.yaml
@@ -20,8 +20,8 @@
         - tftp-server
   
   - set_fact:
-      owner: nobody
-      group: nobody
+      owner: nfsnobody
+      group: nfsnobody
   
   - set_fact:
       services:

--- a/tasks/set_facts_.yaml
+++ b/tasks/set_facts_.yaml
@@ -1,74 +1,70 @@
 ---
-- set_fact:
-    packages:
-      - bind
-      - bind-utils
-      - firewalld
-      - haproxy
-      - httpd
-      - vim
-      - bash-completion
-      - libselinux-python
-      - podman
-      - nfs-utils
+- block:
+  - set_fact:
+      packages:
+        - bind
+        - bind-utils
+        - firewalld
+        - haproxy
+        - httpd
+        - vim
+        - bash-completion
+        - libselinux-python
+        - podman
+        - nfs-utils
+  
+  - set_fact:
+      dhcppkgs:
+        - dhcp
+        - syslinux
+        - tftp-server
+  
+  - set_fact:
+      owner: nobody
+      group: nobody
+  
+  - set_fact:
+      services:
+        - named
+        - haproxy
+        - httpd
+        - rpcbind
+        - nfs-server
+        - nfs-lock
+        - nfs-idmap
   when: ansible_distribution_major_version == "7"
 
-- set_fact:
-    dhcppkgs:
-      - dhcp
-      - syslinux
-      - tftp-server
-  when: ansible_distribution_major_version == "7"
-
-- set_fact:
-    owner: nobody
-    group: nobody
-  when: ansible_distribution_major_version == "7"
-
-- set_fact:
-    services:
-      - named
-      - haproxy
-      - httpd
-      - rpcbind
-      - nfs-server
-      - nfs-lock
-      - nfs-idmap
-  when: ansible_distribution_major_version == "7"
-
-- set_fact:
-    packages:
-      - bind
-      - bind-utils
-      - firewalld
-      - haproxy
-      - httpd
-      - vim
-      - bash-completion
-      - python3-libselinux
-      - podman
-      - nfs-utils
-  when: ansible_distribution_major_version == "8"
-
-- set_fact:
-    dhcppkgs:
-      - dhcp-server
-      - syslinux
-      - tftp-server
-  when: ansible_distribution_major_version == "8"
-
-# See Fedora Wiki for changes:
-# https://fedoraproject.org/wiki/Changes/RenameNobodyUser
-- set_fact:
-    owner: nobody
-    group: nobody
-  when: ansible_distribution_major_version == "8"
-
-- set_fact:
-    services:
-      - named
-      - haproxy
-      - httpd
-      - rpcbind
-      - nfs-server
+- block:
+  - set_fact:
+      packages:
+        - bind
+        - bind-utils
+        - firewalld
+        - haproxy
+        - httpd
+        - vim
+        - bash-completion
+        - python3-libselinux
+        - podman
+        - nfs-utils
+  
+  - set_fact:
+      dhcppkgs:
+        - dhcp-server
+        - syslinux
+        - tftp-server
+  
+  # See Fedora Wiki for changes:
+  # https://fedoraproject.org/wiki/Changes/RenameNobodyUser
+  - set_fact:
+      owner: nobody
+      group: nobody
+  
+  - set_fact:
+      services:
+        - named
+        - haproxy
+        - httpd
+        - rpcbind
+        - nfs-server
   when: ansible_distribution_major_version == "8"


### PR DESCRIPTION
Task takes the following steps assuming there may already be an `id_rsa` key:
- creates .ssh directory if missing
- generates priv/pub keys (`helper_rsa`)
- creates ssh config
  - user connects to cluster nodes via newly generated key
  - user connects to cluster nodes as user `core`
- Updated set_facts.yaml to use `Blocks`

Example: `ansible-playbook -e @vars.yaml -e ssh=True tasks/main.yml ` 

Or update vars.yaml from `ssh_gen_key: False` to `ssh_gen_key: True`

OS: `Red Hat Enterprise Linux release 8.1 (Ootpa)`
Ansible: `v2.9.6`