### PR TITLE
Suggesting hostname validation

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -4,3 +4,4 @@ command_warnings = False
 filter_plugins = filter_plugins
 host_key_checking = False
 deprecation_warnings=False
+retry_files = false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,12 @@
   handlers:
   - import_tasks: ../handlers/main.yml
 
+  # According to RFC 952, and RFC 1123, also RFC about SRV records should be taken into account)
+  # underscores in hostnames are illegal.
+  pre_tasks:
+  - name: validate hostnames
+    import_tasks: validate_host_names.yaml
+
   tasks:
   - name: generate ssh keys
     import_tasks: generate_ssh_keys.yaml

--- a/tasks/validate_host_names.yaml
+++ b/tasks/validate_host_names.yaml
@@ -1,0 +1,24 @@
+- fail:
+    msg: "Please revise your vars.yaml file _underscores_ are not legal in hostnames"
+  when: item is search("_")
+  with_items:
+  - "{{ dns.domain }}"
+  - "{{ helper.name }}"
+  - "{{ bootstrap.name }}"
+  register: val0
+  ignore_errors: True
+
+- fail:
+    msg: "Please revise your vars.yaml file _underscores_ are not legal in hostnames"
+  when: item.name is search("_")
+  with_items:
+  - "{{ masters }}"
+  - "{{ workers }}"
+  register: val1
+  ignore_errors: True
+
+- fail:
+    msg: "Please revise your vars.yaml file _underscores_ are not legal in hostnames"
+  when:
+    (val0.failed is defined) or
+    (val1.failed is defined)


### PR DESCRIPTION
Suggesting adding hostname validation per issue > `named refuses to start #24`

Although underscores in hostnames are “illegal” (according to [RFC 952](https://tools.ietf.org/rfc/rfc952.txt), and [RFC 1123](https://www.ietf.org/rfc/rfc1123.txt), also [RFC about SRV](https://www.ietf.org/rfc/rfc2782.txt) records should be taken into account) they are complying to name restrictions for windows hostname.

Underscores have special use in DNS. Although, if you need to use underscores for your hostnames (i.e. hosts that are using your DHCP might use underscores), you may disable checks in bind.
