### PR TITLE
Make OCP version more configurable

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,14 +1,15 @@
 ---
-ocp_maj_ver: '4.3'
-ocp_min_ver: '4.3.8'
+maj_ver: '4.3'
+ocp_ver: '4.3.8'
+rhcos_ver: '4.3.8'
 ssh_gen_key: true
 install_filetranspiler: false
 staticips: false
 force_ocp_download: false
 base_url: "https://mirror.openshift.com/pub/openshift-v4"
-ocp_bios: "{{base_url}}/dependencies/rhcos/{{ocp_maj_ver}}/{{ocp_min_ver}}/rhcos-{{ocp_min_ver}}-x86_64-metal.x86_64.raw.gz"
-ocp_initramfs: "{{base_url}}/dependencies/rhcos/{{ocp_maj_ver}}/{{ocp_min_ver}}/rhcos-{{ocp_min_ver}}-x86_64-installer-initramfs.x86_64.img"
-ocp_install_kernel: "{{base_url}}/dependencies/rhcos/{{ocp_maj_ver}}/{{ocp_min_ver}}/rhcos-{{ocp_min_ver}}-x86_64-installer-kernel-x86_64"
-ocp_client: "{{base_url}}/clients/ocp/{{ocp_min_ver}}/openshift-client-linux-{{ocp_min_ver}}.tar.gz"
-ocp_installer: "{{base_url}}/clients/ocp/{{ocp_min_ver}}/openshift-install-linux-{{ocp_min_ver}}.tar.gz"
+ocp_bios: "{{base_url}}/dependencies/rhcos/{{maj_ver}}/{{rhcos_ver}}/rhcos-{{rhcos_ver}}-x86_64-metal.x86_64.raw.gz"
+ocp_initramfs: "{{base_url}}/dependencies/rhcos/{{maj_ver}}/{{rhcos_ver}}/rhcos-{{rhcos_ver}}-x86_64-installer-initramfs.x86_64.img"
+ocp_install_kernel: "{{base_url}}/dependencies/rhcos/{{maj_ver}}/{{rhcos_ver}}/rhcos-{{rhcos_ver}}-x86_64-installer-kernel-x86_64"
+ocp_client: "{{base_url}}/clients/ocp/{{ocp_ver}}/openshift-client-linux-{{ocp_ver}}.tar.gz"
+ocp_installer: "{{base_url}}/clients/ocp/{{ocp_ver}}/openshift-install-linux-{{ocp_ver}}.tar.gz"
 chars: (\\_|\\$|\\\|\\/|\\=|\\)|\\(|\\&|\\^|\\%|\\$|\\#|\\@|\\!|\\*)

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,11 +1,14 @@
 ---
+ocp_maj_ver: '4.3'
+ocp_min_ver: '4.3.8'
 ssh_gen_key: true
 install_filetranspiler: false
 staticips: false
 force_ocp_download: false
-ocp_bios: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.3/4.3.8/rhcos-4.3.8-x86_64-metal.x86_64.raw.gz"
-ocp_initramfs: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.3/4.3.8/rhcos-4.3.8-x86_64-installer-initramfs.x86_64.img"
-ocp_install_kernel: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.3/4.3.8/rhcos-4.3.8-x86_64-installer-kernel-x86_64"
-ocp_client: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.3.8/openshift-client-linux-4.3.8.tar.gz"
-ocp_installer: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.3.8/openshift-install-linux-4.3.8.tar.gz"
+base_url: "https://mirror.openshift.com/pub/openshift-v4"
+ocp_bios: "{{base_url}}/dependencies/rhcos/{{ocp_maj_ver}}/{{ocp_min_ver}}/rhcos-{{ocp_min_ver}}-x86_64-metal.x86_64.raw.gz"
+ocp_initramfs: "{{base_url}}/dependencies/rhcos/{{ocp_maj_ver}}/{{ocp_min_ver}}/rhcos-{{ocp_min_ver}}-x86_64-installer-initramfs.x86_64.img"
+ocp_install_kernel: "{{base_url}}/dependencies/rhcos/{{ocp_maj_ver}}/{{ocp_min_ver}}/rhcos-{{ocp_min_ver}}-x86_64-installer-kernel-x86_64"
+ocp_client: "{{base_url}}/clients/ocp/{{ocp_min_ver}}/openshift-client-linux-{{ocp_min_ver}}.tar.gz"
+ocp_installer: "{{base_url}}/clients/ocp/{{ocp_min_ver}}/openshift-install-linux-{{ocp_min_ver}}.tar.gz"
 chars: (\\_|\\$|\\\|\\/|\\=|\\)|\\(|\\&|\\^|\\%|\\$|\\#|\\@|\\!|\\*)


### PR DESCRIPTION
Current vars file has about 13 different places where the version number needs to be changed to move to another OCP version. Update vars file to shorten this to 2 variables. I've tested the playbooks and everything downloads just the same.