### PR TITLE
Fixes for ppc64le (console and PXE) on PowerVM

### DIFF
--- a/tasks/generate_grub.yml
+++ b/tasks/generate_grub.yml
@@ -9,7 +9,7 @@
       timeout=1
       menuentry "CoreOS (BIOS)" {
          echo "Loading kernel"
-         linux "/rhcos/kernel" ip=dhcp console=tty0 console=ttyS0 rd.neednet=1 coreos.inst=yes coreos.inst.install_dev={{ disk }} coreos.inst.image_url=http://{{ helper.ipaddr }}:8080/install/bios.raw.gz coreos.inst.ignition_url=http://{{ helper.ipaddr }}:8080/ignition/{{ role }}.ign
+         linux "/rhcos/kernel" ip=dhcp console=tty0 console=ttyS0 console=hvc0 rd.neednet=1 coreos.inst=yes coreos.inst.install_dev={{ disk }} coreos.inst.image_url=http://{{ helper.ipaddr }}:8080/install/bios.raw.gz coreos.inst.ignition_url=http://{{ helper.ipaddr }}:8080/ignition/{{ role }}.ign
 
          echo "Loading initrd"
          initrd  "/rhcos/initramfs.img"

--- a/tasks/generate_grub.yml
+++ b/tasks/generate_grub.yml
@@ -9,7 +9,7 @@
       timeout=1
       menuentry "CoreOS (BIOS)" {
          echo "Loading kernel"
-         linux "/rhcos/kernel" ip=dhcp console=tty0 console=ttyS0 console=hvc0 rd.neednet=1 coreos.inst=yes coreos.inst.install_dev={{ disk }} coreos.inst.image_url=http://{{ helper.ipaddr }}:8080/install/bios.raw.gz coreos.inst.ignition_url=http://{{ helper.ipaddr }}:8080/ignition/{{ role }}.ign
+         linux "/rhcos/kernel" ip=dhcp console=tty0 console=ttyS0 console=hvc0,115200n8 rd.neednet=1 coreos.inst=yes coreos.inst.install_dev={{ disk }} coreos.inst.image_url=http://{{ helper.ipaddr }}:8080/install/bios.raw.gz coreos.inst.ignition_url=http://{{ helper.ipaddr }}:8080/ignition/{{ role }}.ign
 
          echo "Loading initrd"
          initrd  "/rhcos/initramfs.img"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -189,6 +189,12 @@
     shell: grub2-mknetdir --net-directory=/var/lib/tftpboot
     when: not staticips and ppc64le
 
+  - name: fake pxelinux.0 for ppc64le
+    copy:
+      src: /var/lib/tftpboot/boot/grub2/powerpc-ieee1275/core.elf
+      dest: /var/lib/tftpboot/pxelinux.0
+    when: not staticips and ppc64le
+
   - name: Create TFTP RHCOS dir
     file:
       path: /var/lib/tftpboot/rhcos

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -189,12 +189,6 @@
     shell: grub2-mknetdir --net-directory=/var/lib/tftpboot
     when: not staticips and ppc64le
 
-  - name: fake pxelinux.0 for ppc64le
-    copy:
-      src: /var/lib/tftpboot/boot/grub2/powerpc-ieee1275/core.elf
-      dest: /var/lib/tftpboot/pxelinux.0
-    when: not staticips and ppc64le
-
   - name: Create TFTP RHCOS dir
     file:
       path: /var/lib/tftpboot/rhcos


### PR DESCRIPTION
1. Add hvc0 so that we can get the detailed installation messages for VMs' console on HMC.
2. Since ppc64le does not support regular PXE, we have to use grub2 network boot along with `core.elf` file.

