### PR TITLE
update ssh_config with each node with blockinfile

### DIFF
--- a/tasks/generate_ssh_keys.yaml
+++ b/tasks/generate_ssh_keys.yaml
@@ -10,14 +10,29 @@
    comment: "{{ ansible_env.USER }}@helper"
    state: present
 
-- lineinfile:
+- blockinfile:
     path: "{{ ansible_env.HOME }}/.ssh/config"
-    line: "{{ item.line }}"
     state: present
     backup: yes
     create: yes
-  with_items:
-    - { line: "Host *" }
-    - { line: "    HostName %h.{{ dns.clusterid }}.{{ dns.domain }}" }
-    - { line: "    User core" }
-    - { line: "    IdentityFile {{ ansible_env.HOME }}/.ssh/helper_rsa" }
+    marker: "# {mark} {{ item.name }} MANAGED BLOCK"
+    block: |
+      Host {{ item.name }}
+        HostName %h.{{ dns.clusterid }}.{{ dns.domain }}
+        User core
+        IdentityFile {{ ansible_env.HOME }}/.ssh/helper_rsa
+  loop: "{{ masters + workers }}"
+
+- blockinfile:
+    path: "{{ ansible_env.HOME }}/.ssh/config"
+    state: present
+    backup: yes
+    create: yes
+    marker: "# {mark} {{ item.name }} MANAGED BLOCK"
+    block: |
+      Host {{ item.name }}
+        HostName %h.{{ dns.clusterid }}.{{ dns.domain }}
+        User core
+        IdentityFile {{ ansible_env.HOME }}/.ssh/helper_rsa
+  loop: 
+    - name: "{{ bootstrap.name }}"


### PR DESCRIPTION
This PR aim is to keep default ssh_config and generate a ssh_config entry with `coreos` user and helper ssh_key for each master, worker and bootstrap node only.

before:
```
Host *
  HostName %h.ocp4.power.mpl
  User core
  IdentityFile /root/.ssh/helper_rsa
```

after:
```
# BEGIN master1 MANAGED BLOCK
Host master1
  HostName %h.ocp4.power.mpl
  User core
  IdentityFile /root/.ssh/helper_rsa
# END master1 MANAGED BLOCK
# BEGIN master2 MANAGED BLOCK
Host master2
  HostName %h.ocp4.power.mpl
  User core
  IdentityFile /root/.ssh/helper_rsa
# END master2 MANAGED BLOCK
# BEGIN master3 MANAGED BLOCK
Host master3
  HostName %h.ocp4.power.mpl
  User core
  IdentityFile /root/.ssh/helper_rsa
# END master3 MANAGED BLOCK
# BEGIN worker1 MANAGED BLOCK
Host worker1
  HostName %h.ocp4.power.mpl
  User core
  IdentityFile /root/.ssh/helper_rsa
# END worker1 MANAGED BLOCK
# BEGIN worker2 MANAGED BLOCK
Host worker2
  HostName %h.ocp4.power.mpl
  User core
  IdentityFile /root/.ssh/helper_rsa
# END worker2 MANAGED BLOCK
# BEGIN worker3 MANAGED BLOCK
Host worker3
  HostName %h.ocp4.power.mpl
  User core
  IdentityFile /root/.ssh/helper_rsa
# END worker3 MANAGED BLOCK
# BEGIN bootstrap MANAGED BLOCK
Host bootstrap
  HostName %h.ocp4.power.mpl
  User core
  IdentityFile /root/.ssh/helper_rsa
# END bootstrap MANAGED BLOCK
```