### PR TITLE
Nfs provisioner support for ppc64le + NFS server and path variables

### DIFF
--- a/templates/nfs-provisioner-deployment.yaml.j2
+++ b/templates/nfs-provisioner-deployment.yaml.j2
@@ -17,7 +17,11 @@ spec:
       serviceAccountName: nfs-client-provisioner
       containers:
         - name: nfs-client-provisioner
+{% if ansible_architecture is ppc64le %}
+          image: ibmcom/nfs-client-provisioner-ppc64le:latest
+{% else %}
           image: quay.io/external_storage/nfs-client-provisioner:latest
+{% endif %}
           volumeMounts:
             - name: nfs-client-root
               mountPath: /persistentvolumes
@@ -25,11 +29,11 @@ spec:
             - name: PROVISIONER_NAME
               value: nfs-storage
             - name: NFS_SERVER
-              value: {{ helper.ipaddr }}
+              value: {{ nfs_server | default(helper.ipaddr) }}
             - name: NFS_PATH
-              value: /export
+              value: {{ nfs_path | default('/export') }}
       volumes:
         - name: nfs-client-root
           nfs:
-            server: {{ helper.ipaddr }}
-            path: /export
+            server: {{ nfs_server | default(helper.ipaddr) }}
+            path: {{ nfs_path | default('/export') }}

--- a/templates/nfs-provisioner-deployment.yaml.j2
+++ b/templates/nfs-provisioner-deployment.yaml.j2
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: nfs-client-provisioner
       containers:
         - name: nfs-client-provisioner
-{% if ansible_architecture is sameas ppc64le %}
+{% if ansible_architecture == "ppc64le" %}
           image: ibmcom/nfs-client-provisioner-ppc64le:latest
 {% else %}
           image: quay.io/external_storage/nfs-client-provisioner:latest

--- a/templates/nfs-provisioner-deployment.yaml.j2
+++ b/templates/nfs-provisioner-deployment.yaml.j2
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: nfs-client-provisioner
       containers:
         - name: nfs-client-provisioner
-{% if ansible_architecture is ppc64le %}
+{% if ansible_architecture is sameas ppc64le %}
           image: ibmcom/nfs-client-provisioner-ppc64le:latest
 {% else %}
           image: quay.io/external_storage/nfs-client-provisioner:latest

--- a/templates/nfs-provisioner-deployment.yaml.j2
+++ b/templates/nfs-provisioner-deployment.yaml.j2
@@ -29,11 +29,11 @@ spec:
             - name: PROVISIONER_NAME
               value: nfs-storage
             - name: NFS_SERVER
-              value: {{ nfs_server | default(helper.ipaddr) }}
+              value: {{ nfs.server | default(helper.ipaddr) }}
             - name: NFS_PATH
-              value: {{ nfs_path | default('/export') }}
+              value: {{ nfs.path | default('/export') }}
       volumes:
         - name: nfs-client-root
           nfs:
-            server: {{ nfs_server | default(helper.ipaddr) }}
-            path: {{ nfs_path | default('/export') }}
+            server: {{ nfs.server | default(helper.ipaddr) }}
+            path: {{ nfs.path | default('/export') }}


### PR DESCRIPTION
- NFS provisioner support for ppc64le (quay.io image is not multiarch, need to use another image)

- add the possibility to specify another nfs server and path by using two variables (`nfs_server` and `nfs_path`) ... but keep default value to be `helper.ipaddr` and `/export`
