### PR TITLE
Add coreOS node with fqdn in ssh_config file 

### DIFF
--- a/tasks/generate_ssh_keys.yaml
+++ b/tasks/generate_ssh_keys.yaml
@@ -17,8 +17,11 @@
     create: yes
     marker: "# {mark} {{ item.name }} MANAGED BLOCK"
     block: |
-      Host {{ item.name }} {{ item.name }}.{{ dns.clusterid }}.{{ dns.domain }}
+      Host {{ item.name }}
         HostName %h.{{ dns.clusterid }}.{{ dns.domain }}
+        User core
+        IdentityFile {{ ansible_env.HOME }}/.ssh/helper_rsa
+      Host {{ item.name }}.{{ dns.clusterid }}.{{ dns.domain }}
         User core
         IdentityFile {{ ansible_env.HOME }}/.ssh/helper_rsa
   loop: "{{ masters + workers }}"
@@ -30,8 +33,11 @@
     create: yes
     marker: "# {mark} {{ item.name }} MANAGED BLOCK"
     block: |
-      Host {{ item.name }} {{ item.name }}.{{ dns.clusterid }}.{{ dns.domain }}
+      Host {{ item.name }}
         HostName %h.{{ dns.clusterid }}.{{ dns.domain }}
+        User core
+        IdentityFile {{ ansible_env.HOME }}/.ssh/helper_rsa
+      Host {{ item.name }}.{{ dns.clusterid }}.{{ dns.domain }}
         User core
         IdentityFile {{ ansible_env.HOME }}/.ssh/helper_rsa
   loop: 

--- a/tasks/generate_ssh_keys.yaml
+++ b/tasks/generate_ssh_keys.yaml
@@ -30,7 +30,7 @@
     create: yes
     marker: "# {mark} {{ item.name }} MANAGED BLOCK"
     block: |
-      Host {{ item.name }}
+      Host {{ item.name }} {{ item.name }}.{{ dns.clusterid }}.{{ dns.domain }}
         HostName %h.{{ dns.clusterid }}.{{ dns.domain }}
         User core
         IdentityFile {{ ansible_env.HOME }}/.ssh/helper_rsa

--- a/tasks/generate_ssh_keys.yaml
+++ b/tasks/generate_ssh_keys.yaml
@@ -17,7 +17,7 @@
     create: yes
     marker: "# {mark} {{ item.name }} MANAGED BLOCK"
     block: |
-      Host {{ item.name }}
+      Host {{ item.name }} {{ item.name }}.{{ dns.clusterid }}.{{ dns.domain }}
         HostName %h.{{ dns.clusterid }}.{{ dns.domain }}
         User core
         IdentityFile {{ ansible_env.HOME }}/.ssh/helper_rsa


### PR DESCRIPTION
Add node with fqdn in ssh config file (without re-adding domain and using helper ssh key)

like: 

```
Host master1
  HostName %h.ocp4.power.mpl
  User core
  IdentityFile /root/.ssh/helper_rsa
Host master1.ocp4.power.mpl
  User core
  IdentityFile /root/.ssh/helper_rsa
```