### PR TITLE
HOTFIX

### DIFF
--- a/docs/quickstart-static.md
+++ b/docs/quickstart-static.md
@@ -346,7 +346,7 @@ oc patch configs.imageregistry.operator.openshift.io cluster --type merge --patc
 For PoCs, using `emptyDir` is okay (to use PVs follow [this](https://docs.openshift.com/container-platform/latest/installing/installing_bare_metal/installing-bare-metal.html#registry-configuring-storage-baremetal_installing-bare-metal) doc)
 
 ```
-oc patch configs.imageregistry.operator.openshift.io cluster --type merge --patch '{"spec":{"managementState":"Managed"}}'
+oc patch configs.imageregistry.operator.openshift.io cluster --type merge --patch '{"spec":{"storage":{"emptyDir":{}}}}'
 ```
 
 If you need to expose the registry, run this command


### PR DESCRIPTION
Updating the quickstart-static with the right patch

```
oc patch configs.imageregistry.operator.openshift.io cluster --type merge --patch '{"spec":{"storage":{"emptyDir":{}}}}'
```