### PR TITLE
Fix issue #91 regarding the default pxelinux.cfg file

### DIFF
--- a/docs/vars-doc.md
+++ b/docs/vars-doc.md
@@ -216,6 +216,21 @@ ssh_gen_key: true
 
 Default is set to `true`, set it to `false` if you don't want it to create the SSH KEY or config for you
 
+### PXE default config
+
+**OPTIONAL**  
+
+This section influences the creation of pxe artifacts
+
+```
+pxe:
+  generate_default: true
+```
+
+Default is false to prevent unexpected issues booting hosts in the "other" section.    
+* `pxe.generate_default` - Setting to true Generates a generic default pxe config file with options for hosts not defined in the (bootstrap/master/worker) sections.  It is recommended to modify the template with appropriate boot options 
+`templates/default.j2` -> `/var/lib/tftpboot/pxelinux.cfg/default`
+
 ### Other Nodes
 
 **OPTIONAL**

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -229,6 +229,7 @@
         src: ../templates/default.j2
         dest: /var/lib/tftpboot/pxelinux.cfg/default
         mode: 0555
+      when: "{{ pxe.generate_default | default(false) }}"
       notify:
         - restart tftp
 


### PR DESCRIPTION
Added "when" clause to the section that creates the `default` pxelinux.cfg file, skipping it by default.