### PR TITLE
Compact cluster support

### DIFF
--- a/docs/bmquickstart-static.md
+++ b/docs/bmquickstart-static.md
@@ -141,6 +141,8 @@ openshift-install create manifests
 
 Edit the `manifests/cluster-scheduler-02-config.yml` Kubernetes manifest file to prevent Pods from being scheduled on the control plane machines by setting `mastersSchedulable` to `false`.
 
+> :rotating_light: Skip this step if you're installing a compact cluster
+
 ```shell
 $ sed -i 's/mastersSchedulable: true/mastersSchedulable: false/g' manifests/cluster-scheduler-02-config.yml
 ```

--- a/docs/bmquickstart.md
+++ b/docs/bmquickstart.md
@@ -143,6 +143,8 @@ openshift-install create manifests
 
 Edit the `manifests/cluster-scheduler-02-config.yml` Kubernetes manifest file to prevent Pods from being scheduled on the control plane machines by setting `mastersSchedulable` to `false`.
 
+> :rotating_light: Skip this step if you're installing a compact cluster
+
 ```shell
 $ sed -i 's/mastersSchedulable: true/mastersSchedulable: false/g' manifests/cluster-scheduler-02-config.yml
 ```

--- a/docs/examples/vars-compact-static.yaml
+++ b/docs/examples/vars-compact-static.yaml
@@ -1,0 +1,23 @@
+---
+staticips: true
+helper:
+  name: "helper"
+  ipaddr: "192.168.7.77"
+dns:
+  domain: "example.com"
+  clusterid: "ocp4"
+  forwarder1: "8.8.8.8"
+  forwarder2: "8.8.4.4"
+bootstrap:
+  name: "bootstrap"
+  ipaddr: "192.168.7.20"
+masters:
+  - name: "master0"
+    ipaddr: "192.168.7.21"
+  - name: "master1"
+    ipaddr: "192.168.7.22"
+  - name: "master2"
+    ipaddr: "192.168.7.23"
+other:
+  - name: "non-cluster-vm"
+    ipaddr: "192.168.7.31"

--- a/docs/examples/vars-compact.yaml
+++ b/docs/examples/vars-compact.yaml
@@ -1,0 +1,36 @@
+---
+disk: vda
+helper:
+  name: "helper"
+  ipaddr: "192.168.7.77"
+dns:
+  domain: "example.com"
+  clusterid: "ocp4"
+  forwarder1: "8.8.8.8"
+  forwarder2: "8.8.4.4"
+dhcp:
+  router: "192.168.7.1"
+  bcast: "192.168.7.255"
+  netmask: "255.255.255.0"
+  poolstart: "192.168.7.10"
+  poolend: "192.168.7.30"
+  ipid: "192.168.7.0"
+  netmaskid: "255.255.255.0"
+bootstrap:
+  name: "bootstrap"
+  ipaddr: "192.168.7.20"
+  macaddr: "52:54:00:60:72:67"
+masters:
+  - name: "master0"
+    ipaddr: "192.168.7.21"
+    macaddr: "52:54:00:e7:9d:67"
+  - name: "master1"
+    ipaddr: "192.168.7.22"
+    macaddr: "52:54:00:80:16:23"
+  - name: "master2"
+    ipaddr: "192.168.7.23"
+    macaddr: "52:54:00:d5:1c:39"
+other:
+  - name: "non-cluster-vm"
+    ipaddr: "192.168.7.31"
+    macaddr: "52:54:00:f4:2e:2e"

--- a/docs/iso-maker.md
+++ b/docs/iso-maker.md
@@ -4,6 +4,8 @@ You can create a custom ISO using [Chuckers' ISO Maker repo](https://github.com/
 
 Although very useful, with my opinionated playbook and his opinionated playbook; it makes it difficult to incorporate it within my playbook. Therefore, I've created this little "how to use the ISO maker with the helpernode".
 
+> :rotating_light: This may not work if you're installing a compact cluster!
+
 ## Cloning The Repo
 
 I assume you've done all the steps up to (and including) [creating the ignition files](https://github.com/RedHatOfficial/ocp4-helpernode/blob/master/docs/quickstart-static.md#create-ignition-configs). After the ignition files have been created and copied over to your webserver, clone the ISO maker repo.

--- a/docs/iso-maker.md
+++ b/docs/iso-maker.md
@@ -4,7 +4,7 @@ You can create a custom ISO using [Chuckers' ISO Maker repo](https://github.com/
 
 Although very useful, with my opinionated playbook and his opinionated playbook; it makes it difficult to incorporate it within my playbook. Therefore, I've created this little "how to use the ISO maker with the helpernode".
 
-> :rotating_light: This may not work if you're installing a compact cluster!
+> :rotating_light: Although this should work with a "compact cluster", CoreOS-ISO-Maker was built with a "full cluster" in mind. YMMV
 
 ## Cloning The Repo
 

--- a/docs/quickstart-powervm.md
+++ b/docs/quickstart-powervm.md
@@ -216,6 +216,8 @@ openshift-install create manifests
 
 Edit the `manifests/cluster-scheduler-02-config.yml` Kubernetes manifest file to prevent Pods from being scheduled on the control plane machines by setting `mastersSchedulable` to `false`.
 
+> :rotating_light: Skip this step if you're installing a compact cluster
+
 ```shell
 $ sed -i 's/mastersSchedulable: true/mastersSchedulable: false/g' manifests/cluster-scheduler-02-config.yml
 ```

--- a/docs/quickstart-ppc64le.md
+++ b/docs/quickstart-ppc64le.md
@@ -270,6 +270,8 @@ openshift-install create manifests
 
 Edit the `manifests/cluster-scheduler-02-config.yml` Kubernetes manifest file to prevent Pods from being scheduled on the control plane machines by setting `mastersSchedulable` to `false`.
 
+> :rotating_light: Skip this step if you're installing a compact cluster
+
 ```shell
 $ sed -i 's/mastersSchedulable: true/mastersSchedulable: false/g' manifests/cluster-scheduler-02-config.yml
 ```

--- a/docs/quickstart-static.md
+++ b/docs/quickstart-static.md
@@ -208,6 +208,8 @@ openshift-install create manifests
 
 Edit the `manifests/cluster-scheduler-02-config.yml` Kubernetes manifest file to prevent Pods from being scheduled on the control plane machines by setting `mastersSchedulable` to `false`.
 
+> :rotating_light: Skip this step if you're installing a compact cluster
+
 ```shell
 $ sed -i 's/mastersSchedulable: true/mastersSchedulable: false/g' manifests/cluster-scheduler-02-config.yml
 ```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -256,6 +256,8 @@ openshift-install create manifests
 
 Edit the `manifests/cluster-scheduler-02-config.yml` Kubernetes manifest file to prevent Pods from being scheduled on the control plane machines by setting `mastersSchedulable` to `false`.
 
+> :rotating_light: Skip this step if you're installing a compact cluster
+
 ```shell
 $ sed -i 's/mastersSchedulable: true/mastersSchedulable: false/g' manifests/cluster-scheduler-02-config.yml
 ```

--- a/docs/vars-doc.md
+++ b/docs/vars-doc.md
@@ -139,6 +139,8 @@ masters:
 
 Similar to the master section; this sets up worker node configuration. Please note that this is an array.
 
+> :rotating_light: This section is optional if you're installing a compact cluster
+
 ```
 workers:
   - name: "worker0"
@@ -157,7 +159,7 @@ workers:
 * `workers.macaddr` - The mac address for [dhcp reservation](../templates/dhcpd.conf.j2#L22). This option is not needed if you're doing static ips.
 
 
-**NOTE**: At LEAST 2 workers is needed for installation of OpenShift 4
+**NOTE**: At LEAST 2 workers is needed if you're installing a standard version of OpenShift 4
 
 ## Extra sections
 
@@ -204,7 +206,7 @@ ocp_installer: "file:///tmp/openshift-install-linux-4.2.0-0.nightly-2019-09-16-1
 
 The [default](../vars/main.yml#L4-L8) is to use the latest **stable** OpenShift 4 release.
 
-> Also, you can point this to ANY apache server...not just the OpenShift 4 mirrors (*cough* *cough* disconnected hint here *cough* *cough*)
+> Also, you can point this to ANY apache server...not just the OpenShift 4 mirrors (Useful for disconnected installs)
 
 ### Filetranspiler 
 
@@ -429,4 +431,6 @@ Below are example `vars.yaml` files.
 * [Example of vars.yaml using Static IPs with Nightlies](examples/vars-static-nightlies.yaml)
 * [Example of vars.yaml for Power](examples/vars-ppc64le.yaml)
 * [Example of vars.yaml DHCP and External NFS](examples/vars-nfs.yaml)
-* [Example of vars.yaml which Chrony configuration](examples/vars-chrony.yaml)
+* [Example of vars.yaml with Chrony configuration](examples/vars-chrony.yaml)
+* [Example of vars.yaml setting up a Compact Cluster](examples/vars-compact.yaml)
+* [Example of vars.yaml setting up a Compact Cluster with Static IPs](examples/vars-compact-static.yaml)

--- a/tasks/generate_ssh_keys.yaml
+++ b/tasks/generate_ssh_keys.yaml
@@ -24,7 +24,26 @@
       Host {{ item.name }}.{{ dns.clusterid }}.{{ dns.domain }}
         User core
         IdentityFile {{ ansible_env.HOME }}/.ssh/helper_rsa
-  loop: "{{ masters + workers }}"
+  loop: "{{ masters }}"
+
+- blockinfile:
+    path: "{{ ansible_env.HOME }}/.ssh/config"
+    state: present
+    backup: yes
+    create: yes
+    marker: "# {mark} {{ item.name }} MANAGED BLOCK"
+    block: |
+      Host {{ item.name }}
+        HostName %h.{{ dns.clusterid }}.{{ dns.domain }}
+        User core
+        IdentityFile {{ ansible_env.HOME }}/.ssh/helper_rsa
+      Host {{ item.name }}.{{ dns.clusterid }}.{{ dns.domain }}
+        User core
+        IdentityFile {{ ansible_env.HOME }}/.ssh/helper_rsa
+  loop: "{{ workers }}"
+  when:
+    - workers is defined
+    - workers | length > 0
 
 - blockinfile:
     path: "{{ ansible_env.HOME }}/.ssh/config"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -258,6 +258,9 @@
       with_items: "{{ workers | lower }}"
       notify:
         - restart tftp
+      when:
+        - workers is defined
+        - workers | length > 0
     when: not staticips and not ppc64le
 
   - name: Generate grub2 config files
@@ -289,6 +292,9 @@
         mac: "{{ item.macaddr }}"
       include_tasks: generate_grub.yml
       with_items: "{{ workers }}"
+      when:
+        - workers is defined
+        - workers | length > 0
     when: not staticips and ppc64le
 
 
@@ -413,7 +419,15 @@
         dest: ../machineconfig/99-{{item}}-chrony-configuration.yaml
       loop: 
         - master
+    - name: Generate Chrony machineconfig
+      template:
+        src: ../templates/chrony-machineconfig.j2
+        dest: ../machineconfig/99-{{item}}-chrony-configuration.yaml
+      loop: 
         - worker
+      when:
+        - workers is defined
+        - workers | length > 0
     when: chronyconfig.enabled
 
   - name: Downloading OCP4 client

--- a/tasks/setup_registry.yaml
+++ b/tasks/setup_registry.yaml
@@ -121,6 +121,11 @@
   - name: Process Local Registry information
     shell: "sed -i '1,/Success/d' ../postrun-local-registry-info"
 
+  - name: Mirror NFS image (x86_64)
+    when: setup_registry.autosync_registry
+    shell: |
+      oc image mirror quay.io/external_storage/nfs-client-provisioner:latest registry.{{ dns.clusterid }}.{{ dns.domain }}:5000/nfs-client-provisioner:latest -a ~/.openshift/pull-secret-updated
+
   - name: Mirror NFS image (ppc64le)
     when: ppc64le
     shell: "oc image mirror docker.io/ibmcom/nfs-client-provisioner-ppc64le:latest registry.{{ dns.clusterid }}.{{ dns.domain }}:5000/nfs-client-provisioner-ppc64le:latest -a ~/.openshift/pull-secret-updated"

--- a/tasks/validate_host_names.yaml
+++ b/tasks/validate_host_names.yaml
@@ -21,7 +21,7 @@
   when: item.name is search('{{ chars }}')
   with_items:
   - "{{ workers }}"
-  register: val1
+  register: val2
   when:
     - workers is defined
     - workers | length > 0
@@ -29,6 +29,4 @@
 
 - fail:
     msg: "Please revise your vars.yaml file invalid characters in hostnames"
-  when:
-    (val0.failed is defined) or
-    (val1.failed is defined)
+  when: (val0.failed is defined) or (val1.failed is defined) or (var2.failed is defined)

--- a/tasks/validate_host_names.yaml
+++ b/tasks/validate_host_names.yaml
@@ -1,4 +1,5 @@
-- fail:
+- name: Validate values for DNS compatibility
+  fail:
     msg: "Please revise your vars.yaml file. Invalid characters found in hostnames"
   when: item is search('{{ chars }}')
   with_items:

--- a/tasks/validate_host_names.yaml
+++ b/tasks/validate_host_names.yaml
@@ -5,28 +5,10 @@
   - "{{ dns.domain }}"
   - "{{ helper.name }}"
   - "{{ bootstrap.name }}"
-  register: val0
-  ignore_errors: True
-
-- fail:
-    msg: "Please revise your vars.yaml file invalid characters in hostnames"
-  when: item.name is search('{{ chars }}')
-  with_items:
   - "{{ masters }}"
-  register: val1
-  ignore_errors: True
-
+  - "{{ workers | default('') }}"
+  register: val0
+ 
 - fail:
     msg: "Please revise your vars.yaml file invalid characters in hostnames"
-  when: item.name is search('{{ chars }}')
-  with_items:
-  - "{{ workers }}"
-  register: val2
-  when:
-    - workers is defined
-    - workers | length > 0
-  ignore_errors: True
-
-- fail:
-    msg: "Please revise your vars.yaml file invalid characters in hostnames"
-  when: (val0.failed is defined) or (val1.failed is defined) or (var2.failed is defined)
+  when: (val0.failed is defined)

--- a/tasks/validate_host_names.yaml
+++ b/tasks/validate_host_names.yaml
@@ -13,8 +13,18 @@
   when: item.name is search('{{ chars }}')
   with_items:
   - "{{ masters }}"
+  register: val1
+  ignore_errors: True
+
+- fail:
+    msg: "Please revise your vars.yaml file invalid characters in hostnames"
+  when: item.name is search('{{ chars }}')
+  with_items:
   - "{{ workers }}"
   register: val1
+  when:
+    - workers is defined
+    - workers | length > 0
   ignore_errors: True
 
 - fail:

--- a/tasks/validate_host_names.yaml
+++ b/tasks/validate_host_names.yaml
@@ -7,4 +7,3 @@
   - "{{ bootstrap.name }}"
   - "{{ masters }}"
   - "{{ workers | default('') }}"
-  register: val0

--- a/tasks/validate_host_names.yaml
+++ b/tasks/validate_host_names.yaml
@@ -1,5 +1,5 @@
 - fail:
-    msg: "Please revise your vars.yaml file invalid characters in hostnames"
+    msg: "Please revise your vars.yaml file. Invalid characters found in hostnames"
   when: item is search('{{ chars }}')
   with_items:
   - "{{ dns.domain }}"
@@ -8,7 +8,3 @@
   - "{{ masters }}"
   - "{{ workers | default('') }}"
   register: val0
- 
-- fail:
-    msg: "Please revise your vars.yaml file invalid characters in hostnames"
-  when: (val0.failed is defined)

--- a/templates/checker.sh.j2
+++ b/templates/checker.sh.j2
@@ -40,6 +40,7 @@ echo ""
 echo "======================"
 echo "DNS Lookup for Workers"
 echo "======================"
+{% if workers is defined %}
 {% for w in workers %}
 echo ""
 echo "{{ w.name | lower }}.{{ dns.clusterid }}.{{ dns.domain | lower }}"
@@ -47,6 +48,7 @@ echo "-------------------------------------------------"
 echo "IP: $(dig @localhost {{ w.name | lower }}.{{ dns.clusterid }}.{{ dns.domain | lower }} +short)"
 echo "Reverse: $(dig @localhost -x $(dig @localhost {{ w.name | lower }}.{{ dns.clusterid }}.{{ dns.domain | lower }} +short) +short)"
 {% endfor %}
+{% endif %}
 }
 ###
 dns-etcd () {

--- a/templates/checker.sh.j2
+++ b/templates/checker.sh.j2
@@ -31,6 +31,7 @@ echo "Reverse: $(dig @localhost -x $(dig @localhost {{ m.name | lower }}.{{ dns.
 }
 ###
 dns-workers () {
+{% if workers is defined %}
 echo "======================"
 echo "DNS Config for Workers"
 echo "======================"
@@ -40,7 +41,6 @@ echo ""
 echo "======================"
 echo "DNS Lookup for Workers"
 echo "======================"
-{% if workers is defined %}
 {% for w in workers %}
 echo ""
 echo "{{ w.name | lower }}.{{ dns.clusterid }}.{{ dns.domain | lower }}"
@@ -48,6 +48,10 @@ echo "-------------------------------------------------"
 echo "IP: $(dig @localhost {{ w.name | lower }}.{{ dns.clusterid }}.{{ dns.domain | lower }} +short)"
 echo "Reverse: $(dig @localhost -x $(dig @localhost {{ w.name | lower }}.{{ dns.clusterid }}.{{ dns.domain | lower }} +short) +short)"
 {% endfor %}
+{% else %}
+echo "========================"
+echo "WORKERS WERE NOT DEFINED"
+echo "========================"
 {% endif %}
 }
 ###

--- a/templates/default.j2
+++ b/templates/default.j2
@@ -6,12 +6,12 @@ default menu.c32
  label 1  
  menu label ^1) Install Bootstrap Node
  kernel rhcos/kernel
- append initrd=rhcos/initramfs.img nomodeset rd.neednet=1 coreos.inst=yes coreos.inst.install_dev={{ disk }} coreos.inst.image_url=http://{{ helper.ipaddr }}:8080/install/bios.raw.gz coreos.inst.ignition_url=http://{{ helper.ipaddr }}:8080/ignition/bootstrap.ign
+ append initrd=rhcos/initramfs.img nomodeset rd.neednet=1 ip=dhcp coreos.inst=yes coreos.inst.install_dev={{ disk }} coreos.inst.image_url=http://{{ helper.ipaddr }}:8080/install/bios.raw.gz coreos.inst.ignition_url=http://{{ helper.ipaddr }}:8080/ignition/bootstrap.ign
  label 2  
  menu label ^2) Install Master Node
  kernel rhcos/kernel
- append initrd=rhcos/initramfs.img nomodeset rd.neednet=1 coreos.inst=yes coreos.inst.install_dev={{ disk }} coreos.inst.image_url=http://{{ helper.ipaddr }}:8080/install/bios.raw.gz coreos.inst.ignition_url=http://{{ helper.ipaddr }}:8080/ignition/master.ign
+ append initrd=rhcos/initramfs.img nomodeset rd.neednet=1 ip=dhcp coreos.inst=yes coreos.inst.install_dev={{ disk }} coreos.inst.image_url=http://{{ helper.ipaddr }}:8080/install/bios.raw.gz coreos.inst.ignition_url=http://{{ helper.ipaddr }}:8080/ignition/master.ign
  label 3  
  menu label ^3) Install Worker Node
  kernel rhcos/kernel
- append initrd=rhcos/initramfs.img nomodeset rd.neednet=1 coreos.inst=yes coreos.inst.install_dev={{ disk }} coreos.inst.image_url=http://{{ helper.ipaddr }}:8080/install/bios.raw.gz coreos.inst.ignition_url=http://{{ helper.ipaddr }}:8080/ignition/worker.ign
+ append initrd=rhcos/initramfs.img nomodeset rd.neednet=1 ip=dhcp coreos.inst=yes coreos.inst.install_dev={{ disk }} coreos.inst.image_url=http://{{ helper.ipaddr }}:8080/install/bios.raw.gz coreos.inst.ignition_url=http://{{ helper.ipaddr }}:8080/ignition/worker.ign

--- a/templates/dhcpd.conf.j2
+++ b/templates/dhcpd.conf.j2
@@ -18,9 +18,11 @@ max-lease-time 14400;
 {% for m in masters %}
 		host {{ m.name | lower }} { hardware ethernet {{ m.macaddr }}; fixed-address {{ m.ipaddr }}; }
 {% endfor %}
+{% if workers is defined %}
 {% for w in workers %}
 		host {{ w.name | lower }} { hardware ethernet {{ w.macaddr }}; fixed-address {{ w.ipaddr }}; }
 {% endfor %}
+{% endif %}
 {% if other is defined %}
 {% for o in other %}
 		host {{ o.name }} { hardware ethernet {{ o.macaddr }}; fixed-address {{ o.ipaddr }}; }

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -104,9 +104,15 @@ frontend ingress-http
 backend ingress-http
     balance source
     mode tcp
+{% if workers is defined %}
 {% for w in workers %}
     server {{ w.name | lower }}-http-router{{ loop.index0 }} {{ w.ipaddr }}:80 check
 {% endfor %}
+{% else %}
+{% for m in masters %}
+    server {{ m.name | lower }}-http-router{{ loop.index0 }} {{ m.ipaddr }}:80 check
+{% endfor %}
+{% endif %}
    
 frontend ingress-https
     bind *:443
@@ -117,8 +123,14 @@ frontend ingress-https
 backend ingress-https
     balance source
     mode tcp
+{% if workers is defined %}
 {% for w in workers %}
     server {{ w.name | lower }}-https-router{{ loop.index0 }} {{ w.ipaddr }}:443 check
 {% endfor %}
+{% else %}
+{% for m in masters %}
+    server {{ m.name | lower }}-https-router{{ loop.index0 }} {{ m.ipaddr }}:443 check
+{% endfor %}
+{% endif %}
 
 #---------------------------------------------------------------------

--- a/templates/nfs-provisioner-deployment.yaml.j2
+++ b/templates/nfs-provisioner-deployment.yaml.j2
@@ -22,7 +22,11 @@ spec:
 {% elif ansible_architecture == "ppc64le" %}
           image: ibmcom/nfs-client-provisioner-ppc64le:latest
 {% else %}
+{% if setup_registry.deploy and  setup_registry.autosync_registry %}
+          image: registry.{{ dns.clusterid }}.{{ dns.domain }}:5000/nfs-client-provisioner:latest
+{% else %}
           image: quay.io/external_storage/nfs-client-provisioner:latest
+{% endif %}
 {% endif %}
           volumeMounts:
             - name: nfs-client-root

--- a/templates/pxe-bootstrap.j2
+++ b/templates/pxe-bootstrap.j2
@@ -7,5 +7,5 @@ default menu.c32
  menu label ^1) Install Bootstrap Node
  menu default
  kernel rhcos/kernel
- append initrd=rhcos/initramfs.img nomodeset rd.neednet=1 coreos.inst=yes coreos.inst.install_dev={{ disk }} coreos.inst.image_url=http://{{ helper.ipaddr }}:8080/install/bios.raw.gz coreos.inst.ignition_url=http://{{ helper.ipaddr }}:8080/ignition/bootstrap.ign
+ append initrd=rhcos/initramfs.img nomodeset rd.neednet=1 ip=dhcp coreos.inst=yes coreos.inst.install_dev={{ disk }} coreos.inst.image_url=http://{{ helper.ipaddr }}:8080/install/bios.raw.gz coreos.inst.ignition_url=http://{{ helper.ipaddr }}:8080/ignition/bootstrap.ign
 

--- a/templates/pxe-master.j2
+++ b/templates/pxe-master.j2
@@ -7,5 +7,5 @@ default menu.c32
  menu label ^1) Install Master Node
  menu default
  kernel rhcos/kernel
- append initrd=rhcos/initramfs.img nomodeset rd.neednet=1 coreos.inst=yes coreos.inst.install_dev={{ disk }} coreos.inst.image_url=http://{{ helper.ipaddr }}:8080/install/bios.raw.gz coreos.inst.ignition_url=http://{{ helper.ipaddr }}:8080/ignition/master.ign
+ append initrd=rhcos/initramfs.img nomodeset rd.neednet=1 ip=dhcp coreos.inst=yes coreos.inst.install_dev={{ disk }} coreos.inst.image_url=http://{{ helper.ipaddr }}:8080/install/bios.raw.gz coreos.inst.ignition_url=http://{{ helper.ipaddr }}:8080/ignition/master.ign
 

--- a/templates/pxe-worker.j2
+++ b/templates/pxe-worker.j2
@@ -7,5 +7,5 @@ default menu.c32
  menu label ^1) Install Worker Node
  menu default
  kernel rhcos/kernel
- append initrd=rhcos/initramfs.img nomodeset rd.neednet=1 coreos.inst=yes coreos.inst.install_dev={{ disk }} coreos.inst.image_url=http://{{ helper.ipaddr }}:8080/install/bios.raw.gz coreos.inst.ignition_url=http://{{ helper.ipaddr }}:8080/ignition/worker.ign
+ append initrd=rhcos/initramfs.img nomodeset rd.neednet=1 ip=dhcp coreos.inst=yes coreos.inst.install_dev={{ disk }} coreos.inst.image_url=http://{{ helper.ipaddr }}:8080/install/bios.raw.gz coreos.inst.ignition_url=http://{{ helper.ipaddr }}:8080/ignition/worker.ign
 

--- a/templates/reverse.j2
+++ b/templates/reverse.j2
@@ -19,9 +19,11 @@ $TTL 1W
 {{ helper.ipaddr.split('.')[3] }}	IN	PTR	api.{{ dns.clusterid }}.{{ dns.domain | lower }}.
 {{ helper.ipaddr.split('.')[3] }}	IN	PTR	api-int.{{ dns.clusterid }}.{{ dns.domain | lower }}.
 ;
+{% if workers is defined %}
 {% for w in workers %}
 {{ w.ipaddr.split('.')[3] }}	IN	PTR	{{ w.name | lower }}.{{ dns.clusterid }}.{{ dns.domain | lower }}.
 {% endfor %}
+{% endif %}
 ;
 {% if other is defined %}
 {% for o in other %}

--- a/templates/zonefile.j2
+++ b/templates/zonefile.j2
@@ -35,9 +35,11 @@ registry	IN	A	{{ helper.ipaddr }}
 {% endfor %}
 ;
 ; Create entries for the worker hosts
+{% if workers is defined %}
 {% for w in workers %}
 {{ w.name | lower }}		IN	A	{{ w.ipaddr }}
 {% endfor %}
+{% endif %}
 ;
 ; The ETCd cluster lives on the masters...so point these to the IP of the masters
 {% for m in masters %}


### PR DESCRIPTION
Making edits for compact cluster support. This endeavours to keep the playbook "backwards compatible". The only requirement to create a compact cluster is to _*NOT*_ define `workers`

Example for DHCP:

```

---
disk: vda
helper:
  name: "helper"
  ipaddr: "192.168.7.77"
dns:
  domain: "example.com"
  clusterid: "ocp4"
  forwarder1: "8.8.8.8"
  forwarder2: "8.8.4.4"
dhcp:
  router: "192.168.7.1"
  bcast: "192.168.7.255"
  netmask: "255.255.255.0"
  poolstart: "192.168.7.10"
  poolend: "192.168.7.30"
  ipid: "192.168.7.0"
  netmaskid: "255.255.255.0"
bootstrap:
  name: "bootstrap"
  ipaddr: "192.168.7.20"
  macaddr: "52:54:00:60:72:67"
masters:
  - name: "master0"
    ipaddr: "192.168.7.21"
    macaddr: "52:54:00:e7:9d:67"
  - name: "master1"
    ipaddr: "192.168.7.22"
    macaddr: "52:54:00:80:16:23"
  - name: "master2"
    ipaddr: "192.168.7.23"
    macaddr: "52:54:00:d5:1c:39"
```

This PR also addresses issues #125 #125 #106 #92 