### PR TITLE
Setting  right permissions to zone configuration files

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -71,6 +71,7 @@
     template:
       src: ../templates/zonefile.j2
       dest: /var/named/zonefile.db
+      mode: '0644'
     notify:
       - restart bind
   
@@ -78,6 +79,7 @@
     template:
       src: ../templates/reverse.j2
       dest: /var/named/reverse.db
+      mode: '0644'
     notify:
       - restart bind
   


### PR DESCRIPTION
named service is unable to load the zone config file due to the wrong file permissions. This patch is setting `0644` permissions to the zone configuration files.