### PR TITLE
add search-domain to dhcpd.conf

### DIFF
--- a/templates/dhcpd.conf.j2
+++ b/templates/dhcpd.conf.j2
@@ -8,6 +8,7 @@ max-lease-time 14400;
 	option subnet-mask              {{ dhcp.netmask }};
 	option domain-name-servers      {{ helper.ipaddr }};
 	option domain-name              "{{ dns.clusterid }}.{{ dns.domain | lower }}";
+	option domain-search            "{{ dns.clusterid }}.{{ dns.domain | lower }}", "{{ dns.domain | lower }}";
 
 	subnet {{ dhcp.ipid }} netmask {{ dhcp.netmaskid }} {
 	interface {{ networkifacename }};


### PR DESCRIPTION
Add search domain that will be eventually propagated to the ocp/okd nodes

ocp/okd nodes bootstrapped from ocp-helper using dhcp inherits the dns options for /etc/resolv.conf
solves issue #142 
