### PR TITLE
provide option to remove previous configuration

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,6 +39,10 @@
       state: present
     when: not staticips and not ppc64le
 
+  - name: Remove existing config files
+    import_tasks: remove_old_config_files.yaml
+    when: remove_old_config_files
+
   - name: Write out dhcp file
     template:
       src: ../templates/dhcpd.conf.j2
@@ -67,7 +71,7 @@
   - name: Setting serial number as a fact
     set_fact:
       serialnumber: "{{ dymanicserialnumber.stdout }}"
-  
+
   - name: Write out "{{ dns.domain | lower }}" zone file
     template:
       src: ../templates/zonefile.j2
@@ -75,7 +79,7 @@
       mode: '0644'
     notify:
       - restart bind
-  
+
   - name: Write out reverse zone file
     template:
       src: ../templates/reverse.j2
@@ -83,7 +87,7 @@
       mode: '0644'
     notify:
       - restart bind
-  
+
   - name: Write out haproxy config file
     template:
       src: ../templates/haproxy.cfg.j2
@@ -125,21 +129,12 @@
       url: "{{ ocp_bios }}"
       dest: /var/www/html/install/bios.raw.gz
       mode: 0555
-    when: "'metal' in ocp_bios"
-     
-  - name: Downloading OCP4 installer Bios
-    get_url:
-      url: "{{ ocp_bios }}"
-      dest: /var/www/html/install/rootfs.img
-      mode: 0555
-    when: "'rootfs' in ocp_bios"
-      
   - name: Start firewalld service
     systemd:
       name: firewalld
       state: started
       enabled: yes
-      
+
   - name: Open up firewall ports
     firewalld:
       permanent: yes
@@ -411,13 +406,13 @@
       template:
         src: ../templates/chrony-machineconfig.j2
         dest: ../machineconfig/99-{{item}}-chrony-configuration.yaml
-      loop: 
+      loop:
         - master
     - name: Generate Chrony machineconfig
       template:
         src: ../templates/chrony-machineconfig.j2
         dest: ../machineconfig/99-{{item}}-chrony-configuration.yaml
-      loop: 
+      loop:
         - worker
       when:
         - workers is defined
@@ -479,7 +474,7 @@
       mode: '0755'
       remote_src: true
     when: not ppc64le
-    
+
   - name: Copy helm cli to bin directory for ppc64le
     copy:
       src: /usr/local/src/helm/linux-ppc64le/helm

--- a/tasks/remove_old_config_files.yaml
+++ b/tasks/remove_old_config_files.yaml
@@ -1,0 +1,32 @@
+- name: Remove existing dhcp config
+  file:
+    path: /etc/dhcp/dhcpd.conf
+    state: absent
+
+- name: Remove existing named config
+  file:
+    path: /etc/named.conf
+    state: absent
+
+- name: Remove existing DNS zone files
+  file:
+    path: "/var/named/{{ item }}"
+    state: absent
+  with_items:
+    - "zonefile.db"
+    - "reverse.db"
+
+- name: Remove existing haproxy config
+  file:
+    path: /etc/haproxy/haproxy.cfg
+    state: absent
+
+- name: Remove existing TFTP config
+  file:
+    path: /var/lib/tftpboot/pxelinux.cfg
+    state: absent
+
+- name: Remove existing grub.cfg
+  file:
+    path: /var/lib/tftpboot/boot/grub2/grub.cfg
+    state: absent

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,12 +3,13 @@ ssh_gen_key: true
 install_filetranspiler: false
 staticips: false
 force_ocp_download: false
-ocp_bios: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/4.6.1/rhcos-4.6.1-x86_64-live-rootfs.x86_64.img"
-ocp_initramfs: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/4.6.1/rhcos-4.6.1-x86_64-live-initramfs.x86_64.img"
-ocp_install_kernel: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/4.6.1/rhcos-4.6.1-x86_64-live-kernel-x86_64"
-ocp_client: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.6.1/openshift-client-linux-4.6.1.tar.gz"
-ocp_installer: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.6.1/openshift-install-linux-4.6.1.tar.gz"
-helm_source: "https://get.helm.sh/helm-v3.4.0-linux-amd64.tar.gz"
+remove_old_config_files: false
+ocp_bios: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.5/4.5.2/rhcos-4.5.2-x86_64-metal.x86_64.raw.gz"
+ocp_initramfs: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.5/4.5.2/rhcos-4.5.2-x86_64-installer-initramfs.x86_64.img"
+ocp_install_kernel: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.5/4.5.2/rhcos-4.5.2-x86_64-installer-kernel-x86_64"
+ocp_client: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.5.2/openshift-client-linux-4.5.2.tar.gz"
+ocp_installer: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.5.2/openshift-install-linux-4.5.2.tar.gz"
+helm_source: "https://get.helm.sh/helm-v3.2.4-linux-amd64.tar.gz"
 chars: (\\_|\\$|\\\|\\/|\\=|\\)|\\(|\\&|\\^|\\%|\\$|\\#|\\@|\\!|\\*)
 ppc64le: false
 chronyconfig:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -4,12 +4,12 @@ install_filetranspiler: false
 staticips: false
 force_ocp_download: false
 remove_old_config_files: false
-ocp_bios: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.5/4.5.2/rhcos-4.5.2-x86_64-metal.x86_64.raw.gz"
-ocp_initramfs: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.5/4.5.2/rhcos-4.5.2-x86_64-installer-initramfs.x86_64.img"
-ocp_install_kernel: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.5/4.5.2/rhcos-4.5.2-x86_64-installer-kernel-x86_64"
-ocp_client: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.5.2/openshift-client-linux-4.5.2.tar.gz"
-ocp_installer: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.5.2/openshift-install-linux-4.5.2.tar.gz"
-helm_source: "https://get.helm.sh/helm-v3.2.4-linux-amd64.tar.gz"
+ocp_bios: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/4.6.1/rhcos-4.6.1-x86_64-live-rootfs.x86_64.img"
+ocp_initramfs: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/4.6.1/rhcos-4.6.1-x86_64-live-initramfs.x86_64.img"
+ocp_install_kernel: "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/4.6.1/rhcos-4.6.1-x86_64-live-kernel-x86_64"
+ocp_client: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.6.1/openshift-client-linux-4.6.1.tar.gz"
+ocp_installer: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.6.1/openshift-install-linux-4.6.1.tar.gz"
+helm_source: "https://get.helm.sh/helm-v3.4.0-linux-amd64.tar.gz"
 chars: (\\_|\\$|\\\|\\/|\\=|\\)|\\(|\\&|\\^|\\%|\\$|\\#|\\@|\\!|\\*)
 ppc64le: false
 chronyconfig:


### PR DESCRIPTION
When doing some UPI testing, I found myself tearing down all the infra
and using the playbook to repopulate things.  This was kind of hit or
miss because I would forget to update a file or a MAC address.  This
gives users the ability to nuke and pave a lot of the config files
laid down by the playbook before generating new files.