### PR TITLE
haproxy: Bump client and server timeouts to 4h

### DIFF
--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -51,8 +51,8 @@ defaults
     timeout http-request    10s
     timeout queue           1m
     timeout connect         10s
-    timeout client          1m
-    timeout server          1m
+    timeout client          4h
+    timeout server          4h
     timeout http-keep-alive 10s
     timeout check           10s
     maxconn                 3000


### PR DESCRIPTION
I ran into this when testing OCS; some of our tests use 'oc rsh' with
long-ish runtimes, and they were all failing - while the same tests were
passing on AWS. After some googling, it appears that a four hour (!)
timeout is what's advised for haproxy in an on-prem k8s or OpenShift
deployment.

Signed-off-by: Zack Cerza <zack@redhat.com>