### PR TITLE
PR per issue 175

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -250,6 +250,7 @@
         dest: "/var/lib/tftpboot/pxelinux.cfg/01-{{ item.macaddr | regex_replace (':', '-')}}"
         mode: 0555
       with_items: "{{ masters | lower }}"
+      when: control_only or workers
       notify:
         - restart tftp
 
@@ -261,9 +262,8 @@
       with_items: "{{ workers | lower }}"
       notify:
         - restart tftp
-      when:
-        - workers is defined
-        - workers | length > 0
+      when: (workers and not control_schedulable and not control_only) or
+            (workers and control_schedulable and not control_only)
     when: not staticips and not ppc64le
 
   - name: Generate grub2 config files
@@ -564,4 +564,3 @@
     debug:
       msg:
         - "Please run /usr/local/bin/helpernodecheck for information"
-

--- a/templates/dhcpd.conf.j2
+++ b/templates/dhcpd.conf.j2
@@ -16,10 +16,14 @@ max-lease-time 14400;
         	range {{ dhcp.poolstart }} {{ dhcp.poolend }};
 		# Static entries
 		host {{ bootstrap.name | lower }} { hardware ethernet {{ bootstrap.macaddr }}; fixed-address {{ bootstrap.ipaddr }}; }
+{% if control_only %}
 {% for m in masters %}
 		host {{ m.name | lower }} { hardware ethernet {{ m.macaddr }}; fixed-address {{ m.ipaddr }}; }
 {% endfor %}
-{% if workers is defined %}
+{% elif (workers and not control_schedulable) or (workers and control_schedulable) %}
+{% for m in masters %}
+		host {{ m.name | lower }} { hardware ethernet {{ m.macaddr }}; fixed-address {{ m.ipaddr }}; }
+{% endfor %}
 {% for w in workers %}
 		host {{ w.name | lower }} { hardware ethernet {{ w.macaddr }}; fixed-address {{ w.ipaddr }}; }
 {% endfor %}

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -66,7 +66,6 @@ listen stats
     stats uri /
     monitor-uri /healthz
 
-
 frontend openshift-api-server
     bind *:6443
     default_backend openshift-api-server
@@ -98,11 +97,18 @@ frontend ingress-http
 
 backend ingress-http
     balance source
-{% if workers is defined %}
+{% if control_only %}
+{% for m in masters %}
+    server {{ m.name | lower }}-http-router{{ loop.index0 }} {{ m.ipaddr }}:80 check
+{% endfor %}
+{% elif workers and not control_schedulable %}
 {% for w in workers %}
     server {{ w.name | lower }}-http-router{{ loop.index0 }} {{ w.ipaddr }}:80 check
 {% endfor %}
-{% else %}
+{% elif workers and control_schedulable %}
+{% for w in workers %}
+    server {{ w.name | lower }}-http-router{{ loop.index0 }} {{ w.ipaddr }}:80 check
+{% endfor %}
 {% for m in masters %}
     server {{ m.name | lower }}-http-router{{ loop.index0 }} {{ m.ipaddr }}:80 check
 {% endfor %}
@@ -115,11 +121,18 @@ frontend ingress-https
 
 backend ingress-https
     balance source
-{% if workers is defined %}
+{% if control_only %}
+{% for m in masters %}
+    server {{ m.name | lower }}-https-router{{ loop.index0 }} {{ m.ipaddr }}:443 check
+{% endfor %}
+{% elif workers and not control_schedulable %}
 {% for w in workers %}
     server {{ w.name | lower }}-https-router{{ loop.index0 }} {{ w.ipaddr }}:443 check
 {% endfor %}
-{% else %}
+{% elif workers and control_schedulable %}
+{% for w in workers %}
+    server {{ w.name | lower }}-https-router{{ loop.index0 }} {{ w.ipaddr }}:443 check
+{% endfor %}
 {% for m in masters %}
     server {{ m.name | lower }}-https-router{{ loop.index0 }} {{ m.ipaddr }}:443 check
 {% endfor %}

--- a/templates/reverse.j2
+++ b/templates/reverse.j2
@@ -10,16 +10,18 @@ $TTL 1W
 ; syntax is "last octet" and the host must have fqdn with trailing dot
 1       IN      PTR     helper.{{ dns.clusterid }}.{{ dns.domain }}.
 
+{% if control_only or workers %}
 {% for m in masters %}
 {{ m.ipaddr.split('.')[3] }}	IN	PTR	{{ m.name | lower }}.{{ dns.clusterid }}.{{ dns.domain | lower }}.
 {% endfor %}
+{% endif %}
 ;
 {{ bootstrap.ipaddr.split('.')[3] }}	IN	PTR	{{ bootstrap.name | lower  }}.{{ dns.clusterid }}.{{ dns.domain | lower }}.
 ;
 {{ helper.ipaddr.split('.')[3] }}	IN	PTR	api.{{ dns.clusterid }}.{{ dns.domain | lower }}.
 {{ helper.ipaddr.split('.')[3] }}	IN	PTR	api-int.{{ dns.clusterid }}.{{ dns.domain | lower }}.
 ;
-{% if workers is defined %}
+{% if (workers and not control_schedulable and not control_only) or (workers and control_schedulable and not control_only) %}
 {% for w in workers %}
 {{ w.ipaddr.split('.')[3] }}	IN	PTR	{{ w.name | lower }}.{{ dns.clusterid }}.{{ dns.domain | lower }}.
 {% endfor %}
@@ -29,6 +31,5 @@ $TTL 1W
 {% for o in other %}
 {{ o.ipaddr.split('.')[3] }}	IN	PTR	{{ o.name }}.{{ dns.clusterid }}.{{ dns.domain }}.
 {% endfor %}
-;
 {% endif %}
 ;EOF

--- a/templates/zonefile.j2
+++ b/templates/zonefile.j2
@@ -37,12 +37,14 @@ registry	IN	A	{{ helper.ipaddr }}
 {{ bootstrap.name | lower }}	IN	A	{{ bootstrap.ipaddr }}
 ;
 ; Create entries for the master hosts
+{% if control_only or workers %}
 {% for m in masters %}
 {{ m.name | lower }}		IN	A	{{ m.ipaddr }}
 {% endfor %}
+{% endif %}
 ;
 ; Create entries for the worker hosts
-{% if workers is defined %}
+{% if (workers and not control_schedulable and not control_only) or (workers and control_schedulable and not control_only) %}
 {% for w in workers %}
 {{ w.name | lower }}		IN	A	{{ w.ipaddr }}
 {% endfor %}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,7 +1,7 @@
 ---
 ssh_gen_key: true
-control_schedulable: true # Security anti-pattern regardless of platform. Only enable for testing purposes in a lab.
-control_only: true
+control_schedulable: false # Security anti-pattern regardless of platform. Only enable for testing purposes in a lab.
+control_only: false
 install_filetranspiler: false
 staticips: false
 force_ocp_download: false

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,5 +1,7 @@
 ---
 ssh_gen_key: true
+control_schedulable: true # Security anti-pattern regardless of platform. Only enable for testing purposes in a lab.
+control_only: true
 install_filetranspiler: false
 staticips: false
 force_ocp_download: false


### PR DESCRIPTION
This is a PR per [issue-175](https://github.com/RedHatOfficial/ocp4-helpernode/issues/175) where the helper playbook can be run to support `mastersSchedulable: true` in a traditional 3x control plane 3 x worker node cluster. However, this comes with a caveat, that running the ingress or any other unnecessary load on the control plane is **not** recommended due to adhering to strict security practice but okay for a lab.

In addition, one can now run the helper playbook to support a compact 3 control/worker node cluster by configuring the following services.

- HAProxy 
- DHCP
- Bind
- pxelinux


Tested on libvirt with dhcp
```
Client Version: 4.6.1
Server Version: 4.6.1
Kubernetes Version: v1.19.0+d59ce34
```

The `vars/main.yml` file now includes two options one to enable support for a cluster with a scheduled control plane. This adds the label `node-role.kubernetes.io/worker=` to your control plane and allows the scheduler to place application workloads. The playbook configures HAproxy to monitor the control plane for the ingress routers.

A second option was also added to support a compact cluster made up of 3 nodes both running the control and application workload.

`vars.yaml`
```
control_schedulable: true
control_only: true
```

Please remember **not** to run this command as it disables the control plane when running a compact cluster.
```
$ sed -i 's/mastersSchedulable: true/mastersSchedulable: false/g' manifests/cluster-scheduler-02-config.yml
```

Also note that in one of my tests I modified the ingress manifest by adding a `nodePlacement` `matchLabel` to include the control plane. Simply, I could not tell that it was applied instead the ingress routers were allowed to run on the control plane since they were schedulable.

(example not needed/did not work/done incorrectly?)

```
sed -i '/domain/a\  nodePlacement:\n\    matchLabels:\n\      node-role.kubernetes.io/worker: ""\n\      node-role.kubernetes.io/master: ""' /root/ocp4/manifests/cluster-ingress-02-config.yml
```

Lastly, because the master and worker objects are such an integral part of the playbook I did not want to rework more than I thought necessary. For the time being, to deploy the helper node to support a compact 3 node cluster you will have to list your control plane nodes twice as showing in the example.

```
---
disk: vda
helper:
  name: "helper"
  ipaddr: "192.168.7.5"
dns:
  domain: "freebsd.us"
  clusterid: "ocp4"
  forwarder1: "8.8.8.8"
  forwarder2: "8.8.4.4"
dhcp:
  router: "192.168.7.1"
  bcast: "192.168.7.255"
  netmask: "255.255.255.0"
  poolstart: "192.168.7.100"
  poolend: "192.168.7.150"
  ipid: "192.168.7.0"
  netmaskid: "255.255.255.0"
bootstrap:
  name: "bootstrap"
  ipaddr: "192.168.7.20"
  macaddr: "52:54:00:c6:a8:45"
masters:
  - name: "master0"
    ipaddr: "192.168.7.21"
    macaddr: "52:54:00:d7:c1:c3"
  - name: "master1"
    ipaddr: "192.168.7.22"
    macaddr: "52:54:00:60:d3:83"
  - name: "master2"
    ipaddr: "192.168.7.23"
    macaddr: "52:54:00:14:bf:0b"
workers:
  - name: "master0"
    ipaddr: "192.168.7.21"
    macaddr: "52:54:00:d7:c1:c3"
  - name: "master1"
    ipaddr: "192.168.7.22"
    macaddr: "52:54:00:60:d3:83"
  - name: "master2"
    ipaddr: "192.168.7.23"
    macaddr: "52:54:00:14:bf:0b"
```

![3-control-plane-cluster00](https://user-images.githubusercontent.com/71178706/99161091-11d3e400-26b4-11eb-8e34-f9a6981a25f1.png)
![control-node-cluster](https://user-images.githubusercontent.com/71178706/99161093-15676b00-26b4-11eb-9ee8-4137985ed4c5.png)
