### PR TITLE
PR per Issue #175

### DIFF
--- a/tasks/generate_ssh_keys.yaml
+++ b/tasks/generate_ssh_keys.yaml
@@ -41,9 +41,7 @@
         User core
         IdentityFile {{ ansible_env.HOME }}/.ssh/helper_rsa
   loop: "{{ workers }}"
-  when:
-    - workers is defined
-    - workers | length > 0
+  when: workers_schedulable
 
 - blockinfile:
     path: "{{ ansible_env.HOME }}/.ssh/config"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -250,6 +250,7 @@
         dest: "/var/lib/tftpboot/pxelinux.cfg/01-{{ item.macaddr | regex_replace (':', '-')}}"
         mode: 0555
       with_items: "{{ masters | lower }}"
+      when: (control_only) or (workers_schedulable)
       notify:
         - restart tftp
 
@@ -261,9 +262,7 @@
       with_items: "{{ workers | lower }}"
       notify:
         - restart tftp
-      when:
-        - workers is defined
-        - workers | length > 0
+      when: workers_schedulable
     when: not staticips and not ppc64le
 
   - name: Generate grub2 config files
@@ -303,11 +302,8 @@
         mac: "{{ item.macaddr }}"
       include_tasks: generate_grub.yml
       with_items: "{{ workers }}"
-      when:
-        - workers is defined
-        - workers | length > 0
+      when: workers_schedulable
     when: not staticips and ppc64le
-
 
   - name: Installing TFTP Systemd helper
     copy:
@@ -431,9 +427,7 @@
         dest: ../machineconfig/99-{{item}}-chrony-configuration.yaml
       loop:
         - worker
-      when:
-        - workers is defined
-        - workers | length > 0
+      when: workers_schedulable
     when: chronyconfig.enabled
 
   - name: Downloading OCP4 client
@@ -564,4 +558,3 @@
     debug:
       msg:
         - "Please run /usr/local/bin/helpernodecheck for information"
-

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -92,6 +92,7 @@
     template:
       src: ../templates/haproxy.cfg.j2
       dest: /etc/haproxy/haproxy.cfg
+      backup: yes
     notify:
       - restart haproxy
 

--- a/tasks/validate_host_names.yaml
+++ b/tasks/validate_host_names.yaml
@@ -1,10 +1,25 @@
-- name: Validate values for DNS compatibility
-  fail:
-    msg: "Please revise your vars.yaml file. Invalid characters found in hostnames"
-  when: item is search('{{ chars }}')
-  with_items:
-  - "{{ dns.domain }}"
-  - "{{ helper.name }}"
-  - "{{ bootstrap.name }}"
-  - "{{ masters }}"
-  - "{{ workers | default('') }}"
+- name: "Validate values for DNS compatibility"
+  block:
+  - name: "Check all inventory"
+    fail:
+      msg: "Please revise your vars.yaml file. Invalid characters found in hostnames"
+    when: item is search('{{ chars }}')
+    with_items:
+    - "{{ dns.domain }}"
+    - "{{ helper.name }}"
+    - "{{ bootstrap.name }}"
+    - "{{ masters }}"
+    - "{{ workers | default('') }}"
+  when: workers_schedulable
+- name: "Validate values for DNS compatibility"
+  block:
+  - name: "Check all inventory"
+    fail:
+      msg: "Please revise your vars.yaml file. Invalid characters found in hostnames"
+    when: item is search('{{ chars }}')
+    with_items:
+    - "{{ dns.domain }}"
+    - "{{ helper.name }}"
+    - "{{ bootstrap.name }}"
+    - "{{ masters }}"
+  when: control_only

--- a/templates/checker.sh.j2
+++ b/templates/checker.sh.j2
@@ -31,7 +31,7 @@ echo "Reverse: $(dig @localhost -x $(dig @localhost {{ m.name | lower }}.{{ dns.
 }
 ###
 dns-workers () {
-{% if workers is defined %}
+{% if workers_schedulable %}
 echo "======================"
 echo "DNS Config for Workers"
 echo "======================"

--- a/templates/dhcpd.conf.j2
+++ b/templates/dhcpd.conf.j2
@@ -16,10 +16,12 @@ max-lease-time 14400;
         	range {{ dhcp.poolstart }} {{ dhcp.poolend }};
 		# Static entries
 		host {{ bootstrap.name | lower }} { hardware ethernet {{ bootstrap.macaddr }}; fixed-address {{ bootstrap.ipaddr }}; }
+{% if control_only or workers_schedulable %}
 {% for m in masters %}
 		host {{ m.name | lower }} { hardware ethernet {{ m.macaddr }}; fixed-address {{ m.ipaddr }}; }
 {% endfor %}
-{% if workers is defined %}
+{% endif %}
+{% if workers_schedulable %}
 {% for w in workers %}
 		host {{ w.name | lower }} { hardware ethernet {{ w.macaddr }}; fixed-address {{ w.ipaddr }}; }
 {% endfor %}

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -66,7 +66,6 @@ listen stats
     stats uri /
     monitor-uri /healthz
 
-
 frontend openshift-api-server
     bind *:6443
     default_backend openshift-api-server
@@ -98,13 +97,14 @@ frontend ingress-http
 
 backend ingress-http
     balance source
-{% if workers is defined %}
-{% for w in workers %}
-    server {{ w.name | lower }}-http-router{{ loop.index0 }} {{ w.ipaddr }}:80 check
-{% endfor %}
-{% else %}
+{% if control_only or control_schedulable %}
 {% for m in masters %}
     server {{ m.name | lower }}-http-router{{ loop.index0 }} {{ m.ipaddr }}:80 check
+{% endfor %}
+{% endif %}
+{% if workers_schedulable %}
+{% for w in workers %}
+    server {{ w.name | lower }}-http-router{{ loop.index0 }} {{ w.ipaddr }}:80 check
 {% endfor %}
 {% endif %}
    
@@ -115,14 +115,14 @@ frontend ingress-https
 
 backend ingress-https
     balance source
-{% if workers is defined %}
-{% for w in workers %}
-    server {{ w.name | lower }}-https-router{{ loop.index0 }} {{ w.ipaddr }}:443 check
-{% endfor %}
-{% else %}
+{% if control_only or control_schedulable %}
 {% for m in masters %}
     server {{ m.name | lower }}-https-router{{ loop.index0 }} {{ m.ipaddr }}:443 check
 {% endfor %}
 {% endif %}
-
+{% if workers_schedulable %}
+{% for w in workers %}
+    server {{ w.name | lower }}-https-router{{ loop.index0 }} {{ w.ipaddr }}:443 check
+{% endfor %}
+{% endif %}
 #---------------------------------------------------------------------

--- a/templates/reverse.j2
+++ b/templates/reverse.j2
@@ -10,16 +10,18 @@ $TTL 1W
 ; syntax is "last octet" and the host must have fqdn with trailing dot
 1       IN      PTR     helper.{{ dns.clusterid }}.{{ dns.domain }}.
 
+{% if control_only or workers_schedulable %}
 {% for m in masters %}
 {{ m.ipaddr.split('.')[3] }}	IN	PTR	{{ m.name | lower }}.{{ dns.clusterid }}.{{ dns.domain | lower }}.
 {% endfor %}
+{% endif %}
 ;
 {{ bootstrap.ipaddr.split('.')[3] }}	IN	PTR	{{ bootstrap.name | lower  }}.{{ dns.clusterid }}.{{ dns.domain | lower }}.
 ;
 {{ helper.ipaddr.split('.')[3] }}	IN	PTR	api.{{ dns.clusterid }}.{{ dns.domain | lower }}.
 {{ helper.ipaddr.split('.')[3] }}	IN	PTR	api-int.{{ dns.clusterid }}.{{ dns.domain | lower }}.
 ;
-{% if workers is defined %}
+{% if workers_schedulable %}
 {% for w in workers %}
 {{ w.ipaddr.split('.')[3] }}	IN	PTR	{{ w.name | lower }}.{{ dns.clusterid }}.{{ dns.domain | lower }}.
 {% endfor %}
@@ -29,6 +31,5 @@ $TTL 1W
 {% for o in other %}
 {{ o.ipaddr.split('.')[3] }}	IN	PTR	{{ o.name }}.{{ dns.clusterid }}.{{ dns.domain }}.
 {% endfor %}
-;
 {% endif %}
 ;EOF

--- a/templates/zonefile.j2
+++ b/templates/zonefile.j2
@@ -37,12 +37,14 @@ registry	IN	A	{{ helper.ipaddr }}
 {{ bootstrap.name | lower }}	IN	A	{{ bootstrap.ipaddr }}
 ;
 ; Create entries for the master hosts
+{% if control_only or workers_schedulable %}
 {% for m in masters %}
 {{ m.name | lower }}		IN	A	{{ m.ipaddr }}
 {% endfor %}
+{% endif %}
 ;
 ; Create entries for the worker hosts
-{% if workers is defined %}
+{% if  workers_schedulable %}
 {% for w in workers %}
 {{ w.name | lower }}		IN	A	{{ w.ipaddr }}
 {% endfor %}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,5 +1,8 @@
 ---
 ssh_gen_key: true
+control_only: true
+control_schedulable: true
+workers_schedulable: false
 install_filetranspiler: false
 staticips: false
 force_ocp_download: false

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,8 +1,8 @@
 ---
 ssh_gen_key: true
-control_only: true
-control_schedulable: true
-workers_schedulable: false
+control_only: false
+control_schedulable: false
+workers_schedulable: true
 install_filetranspiler: false
 staticips: false
 force_ocp_download: false


### PR DESCRIPTION
Per issue [175](https://github.com/RedHatOfficial/ocp4-helpernode/issues/175) - I would like to submit this for review.

What I have done is added the following three variables which tells the playbook the type of deployment is required.

For a default deployment one would leave `vars/main.yaml` as is (vars can be changed to whatever is deemed appr).

```
control_only: false
control_schedulable: false
workers_schedulable: true
```
The reason being is that currently, the `workers` variable is being used in the conditional checks which causes failure for those wanting to run compact clusters passing vars.yaml such as the example below. Instead, something like `workers_schedulable: true` can be defined.


If you intend to run a compact cluster where your control plane & worker in 1. This sets up services on the helper node for the control plane only. Here's an example playbook. [Ref-1]

```
control_only: true
control_schedulable: true
workers_schedulable: false
```

[Ref-1]
```
---
disk: vda
helper:
  name: "helper"
  ipaddr: "192.168.7.5"
dns:
  domain: "example.com"
  clusterid: "ocp4"
  forwarder1: "8.8.8.8"
  forwarder2: "8.8.4.4"
dhcp:
  router: "192.168.7.1"
  bcast: "192.168.7.255"
  netmask: "255.255.255.0"
  poolstart: "192.168.7.100"
  poolend: "192.168.7.150"
  ipid: "192.168.7.0"
  netmaskid: "255.255.255.0"
bootstrap:
  name: "bootstrap"
  ipaddr: "192.168.7.20"
  macaddr: "52:54:00:91:1a:bb"
masters:
  - name: "control0"
    ipaddr: "192.168.7.21"
    macaddr: "52:54:00:a4:06:47"
  - name: "control1"
    ipaddr: "192.168.7.22"
    macaddr: "52:54:00:29:a8:29"
  - name: "control2"
    ipaddr: "192.168.7.23"
    macaddr: "52:54:00:38:7a:8e"
```
Otherwise, if you intend to run the ingress routers on the control plane by making it schedulable. One can use the normal vars.yaml example provided by the playbook.


```
control_only: false
control_schedulable: true
workers_schedulable: true
```

```
---
disk: vda
helper:
  name: "helper"
  ipaddr: "192.168.7.5"
dns:
  domain: "domain.com"
  clusterid: "ocp4"
  forwarder1: "8.8.8.8"
  forwarder2: "8.8.4.4"
dhcp:
  router: "192.168.7.1"
  bcast: "192.168.7.255"
  netmask: "255.255.255.0"
  poolstart: "192.168.7.100"
  poolend: "192.168.7.150"
  ipid: "192.168.7.0"
  netmaskid: "255.255.255.0"
bootstrap:
  name: "bootstrap"
  ipaddr: "192.168.7.20"
  macaddr: "52:54:00:91:1a:bb"
masters:
  - name: "control0"
    ipaddr: "192.168.7.21"
    macaddr: "52:54:00:a4:06:47"
  - name: "control1"
    ipaddr: "192.168.7.22"
    macaddr: "52:54:00:29:a8:29"
  - name: "control2"
    ipaddr: "192.168.7.23"
    macaddr: "52:54:00:38:7a:8e"
workers:
  - name: "worker0"
    ipaddr: "192.168.7.24"
    macaddr: "52:54:00:e0:00:11"
  - name: "worker1"
    ipaddr: "192.168.7.25"
    macaddr: "52:54:00:ff:12:60"
  - name: "worker2"
    ipaddr: "192.168.7.26"
    macaddr: "52:54:00:1c:28:b6"
```

Please let me know your thoughts or suggestions?

Thanks!