### PR TITLE
Support static ip addresses in pxe configuration

### DIFF
--- a/templates/pxe-bootstrap.j2
+++ b/templates/pxe-bootstrap.j2
@@ -1,3 +1,13 @@
+{% if bootstrap.ipaddr is defined and bootstrap.networkifacename is defined %}
+  {% set ipconfig = bootstrap.ipaddr + "::" + dhcp.router + ":" + dhcp.netmask + ":" + bootstrap.name + ":" + bootstrap.networkifacename + ":none" %}
+  {% set ipconfig = ipconfig + " nameserver=" + dns.forwarder1 %}
+  {% if dns.forwarder2 is defined %}
+    {% set ipconfig = ipconfig + " nameserver=" + dns.forwarder2 %}
+  {% endif %}
+{% else %}
+  {% set ipconfig = "dhcp" %}
+{% endif %}
+
 default menu.c32   
  prompt 1
  timeout 9
@@ -7,5 +17,5 @@ default menu.c32
  menu label ^1) Install Bootstrap Node
  menu default
  kernel rhcos/kernel
- append initrd=rhcos/initramfs.img nomodeset rd.neednet=1 ip=dhcp coreos.inst=yes coreos.inst.install_dev={{ disk }} {% if "metal" in ocp_bios %} coreos.inst.image_url=http://{{ helper.ipaddr }}:8080/install/bios.raw.gz {% elif "rootfs" in ocp_bios %} coreos.live.rootfs_url=http://{{ helper.ipaddr }}:8080/install/rootfs.img {% else %} coreos.UNKNOWN.CONFIG=you_messed_up {% endif %} coreos.inst.ignition_url=http://{{ helper.ipaddr }}:8080/ignition/bootstrap.ign
+ append initrd=rhcos/initramfs.img nomodeset rd.neednet=1 ip={{ ipconfig }} coreos.inst=yes coreos.inst.install_dev={{ disk }} {% if "metal" in ocp_bios %} coreos.inst.image_url=http://{{ helper.ipaddr }}:8080/install/bios.raw.gz {% elif "rootfs" in ocp_bios %} coreos.live.rootfs_url=http://{{ helper.ipaddr }}:8080/install/rootfs.img {% else %} coreos.UNKNOWN.CONFIG=you_messed_up {% endif %} coreos.inst.ignition_url=http://{{ helper.ipaddr }}:8080/ignition/bootstrap.ign
 

--- a/templates/pxe-master.j2
+++ b/templates/pxe-master.j2
@@ -1,11 +1,20 @@
-default menu.c32   
+{% if item.ipaddr is defined and item.networkifacename is defined %}
+  {% set ipconfig = item.ipaddr + "::" + dhcp.router + ":" + dhcp.netmask + ":" + item.name + ":" + item.networkifacename + ":none" %}
+  {% set ipconfig = ipconfig + " nameserver=" + dns.forwarder1 %}
+  {% if dns.forwarder2 is defined %}
+    {% set ipconfig = ipconfig + " nameserver=" + dns.forwarder2 %}
+  {% endif %}
+{% else %}
+  {% set ipconfig = "dhcp" %}
+{% endif %}
+
+default menu.c32
  prompt 1
  timeout 9
  ONTIMEOUT 1
- menu title ######## PXE Boot Menu ########  
+ menu title ######## PXE Boot Menu ########
  label 1
  menu label ^1) Install Master Node
  menu default
  kernel rhcos/kernel
- append initrd=rhcos/initramfs.img nomodeset rd.neednet=1 ip=dhcp coreos.inst=yes coreos.inst.install_dev={{ disk }} {% if "metal" in ocp_bios %} coreos.inst.image_url=http://{{ helper.ipaddr }}:8080/install/bios.raw.gz {% elif "rootfs" in ocp_bios %} coreos.live.rootfs_url=http://{{ helper.ipaddr }}:8080/install/rootfs.img {% else %} coreos.UNKNOWN.CONFIG=you_messed_up {% endif %} coreos.inst.ignition_url=http://{{ helper.ipaddr }}:8080/ignition/master.ign
-
+ append initrd=rhcos/initramfs.img nomodeset rd.neednet=1 ip={{ ipconfig }} coreos.inst=yes coreos.inst.install_dev={{ disk }} {% if "metal" in ocp_bios %} coreos.inst.image_url=http://{{ helper.ipaddr }}:8080/install/bios.raw.gz {% elif "rootfs" in ocp_bios %} coreos.live.rootfs_url=http://{{ helper.ipaddr }}:8080/install/rootfs.img {% else %} coreos.UNKNOWN.CONFIG=you_messed_up {% endif %} coreos.inst.ignition_url=http://{{ helper.ipaddr }}:8080/ignition/master.ign

--- a/templates/pxe-worker.j2
+++ b/templates/pxe-worker.j2
@@ -1,11 +1,20 @@
-default menu.c32   
+{% if item.ipaddr is defined and item.networkifacename is defined %}
+  {% set ipconfig = item.ipaddr + "::" + dhcp.router + ":" + dhcp.netmask + ":" + item.name + ":" + item.networkifacename + ":none" %}
+  {% set ipconfig = ipconfig + " nameserver=" + dns.forwarder1 %}
+  {% if dns.forwarder2 is defined %}
+    {% set ipconfig = ipconfig + " nameserver=" + dns.forwarder2 %}
+  {% endif %}
+{% else %}
+  {% set ipconfig = "dhcp" %}
+{% endif %}
+
+default menu.c32
  prompt 1
  timeout 9
  ONTIMEOUT 1
- menu title ######## PXE Boot Menu ########  
+ menu title ######## PXE Boot Menu ########
  label 1
  menu label ^1) Install Worker Node
  menu default
  kernel rhcos/kernel
- append initrd=rhcos/initramfs.img nomodeset rd.neednet=1 ip=dhcp coreos.inst=yes coreos.inst.install_dev={{ disk }} {% if "metal" in ocp_bios %} coreos.inst.image_url=http://{{ helper.ipaddr }}:8080/install/bios.raw.gz {% elif "rootfs" in ocp_bios %} coreos.live.rootfs_url=http://{{ helper.ipaddr }}:8080/install/rootfs.img {% else %} coreos.UNKNOWN.CONFIG=you_messed_up {% endif %} coreos.inst.ignition_url=http://{{ helper.ipaddr }}:8080/ignition/worker.ign
-
+ append initrd=rhcos/initramfs.img nomodeset rd.neednet=1 ip={{ ipconfig }} coreos.inst=yes coreos.inst.install_dev={{ disk }} {% if "metal" in ocp_bios %} coreos.inst.image_url=http://{{ helper.ipaddr }}:8080/install/bios.raw.gz {% elif "rootfs" in ocp_bios %} coreos.live.rootfs_url=http://{{ helper.ipaddr }}:8080/install/rootfs.img {% else %} coreos.UNKNOWN.CONFIG=you_messed_up {% endif %} coreos.inst.ignition_url=http://{{ helper.ipaddr }}:8080/ignition/worker.ign


### PR DESCRIPTION
This commit adds two new optional variables (ipaddr and networkifacename) to
node definitions in vars.yaml:

masters:
  - name: "master01"
    ipaddr: "10.0.0.182"
    macaddr: "52:54:00:01:01:82"
    networkifacename: ens3
workers:
  - name: "infra01"
    ipaddr: "10.0.0.185"
    macaddr: "52:54:00:01:01:85"
    networkifacename: ens3

We use this in pxe templates to specify static IP address for
nodes. so DHCP is only need when bootstrapping new nodes.

The default of DHCP for node IP configuration is _not_ changed.

The configuration for the master nodes above creates the following
'append' entry in the pxe config file:

append initrd=rhcos/initramfs.img nomodeset rd.neednet=1 ip=10.0.0.182::10.0.0.138:255.255.255.0:master01:ens3:none nameserver=10.0.0.254 coreos.inst=yes coreos.inst.install_dev=vda  coreos.live.rootfs_url=http://10.0.0.180:8080/install/rootfs.img  coreos.inst.ignition_url=http://10.0.0.180:8080/ignition/master.ign