### PR TITLE
added UEFI network boot support

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -267,6 +267,58 @@
         - workers | length > 0
     when: not staticips and not ppc64le
 
+  - name: Prepare UEFI netboot configuration
+    block:
+    - name: Create tftp grub2 directory
+      file:
+        path: /var/lib/tftpboot/grub2
+        state: directory
+        mode: '0755'
+
+    - name: copy UEFI shim to grub2 tftpboot/grub2 directory
+      copy:
+        src: /boot/efi/EFI/redhat/shimx64.efi
+        dest: /var/lib/tftpboot/grub2/shimx64.efi
+        mode: '0555'
+        remote_src: yes
+
+    - name: copy grub2 EFI file to tftpboot/grub2 directory
+      copy:
+        src: /boot/efi/EFI/redhat/grubx64.efi
+        dest: /var/lib/tftpboot/grub2/grubx64.efi
+        mode: '0555'
+        remote_src: yes
+
+    - name: Create the bootstrap specific grub2 file
+      template:
+        src: ../templates/grub2-bootstrap.j2
+        dest: "/var/lib/tftpboot/grub2/grub.cfg-01-{{ bootstrap.macaddr | lower | regex_replace (':', '-')}}"
+        mode: 0555
+      notify:
+        - restart tftp
+
+    - name: Set the master specific tftp files
+      template:
+        src: ../templates/grub2-master.j2
+        dest: "/var/lib/tftpboot/grub2/grub.cfg-01-{{ item.macaddr | regex_replace (':', '-')}}"
+        mode: 0555
+      with_items: "{{ masters | lower }}"
+      notify:
+        - restart tftp
+
+    - name: Set the worker specific tftp files
+      template:
+        src: ../templates/grub2-worker.j2
+        dest: "/var/lib/tftpboot/grub2/grub.cfg-01-{{ item.macaddr | regex_replace (':', '-')}}"
+        mode: 0555
+      with_items: "{{ workers | lower }}"
+      notify:
+        - restart tftp
+      when:
+        - workers is defined
+        - workers | length > 0
+    when: not staticips and not ppc64le
+
   - name: Generate grub2 config files
     block:
     - set_fact:

--- a/tasks/set_facts_.yaml
+++ b/tasks/set_facts_.yaml
@@ -39,6 +39,8 @@
         - libselinux-python
         - podman
         - nfs-utils
+        - shim-x64
+        - grub2-efi-x64
   
   - set_fact:
       dhcppkgs:

--- a/templates/dhcpd.conf.j2
+++ b/templates/dhcpd.conf.j2
@@ -3,44 +3,61 @@ ddns-update-style interim;
 default-lease-time 14400;
 max-lease-time 14400;
 
-	option routers                  {{ dhcp.router }};
-	option broadcast-address        {{ dhcp.bcast }};
-	option subnet-mask              {{ dhcp.netmask }};
-	option domain-name-servers      {{ helper.ipaddr }};
-	option domain-name              "{{ dns.clusterid }}.{{ dns.domain | lower }}";
-	option domain-search            "{{ dns.clusterid }}.{{ dns.domain | lower }}", "{{ dns.domain | lower }}";
+option routers                  {{ dhcp.router }};
+option broadcast-address        {{ dhcp.bcast }};
+option subnet-mask              {{ dhcp.netmask }};
+option domain-name-servers      {{ helper.ipaddr }};
+option domain-name              "{{ dns.clusterid }}.{{ dns.domain | lower }}";
+option domain-search            "{{ dns.clusterid }}.{{ dns.domain | lower }}", "{{ dns.domain | lower }}";
 
-	subnet {{ dhcp.ipid }} netmask {{ dhcp.netmaskid }} {
-	interface {{ networkifacename }};
-     	pool {
-        	range {{ dhcp.poolstart }} {{ dhcp.poolend }};
-		# Static entries
+# required for UEFI support
+option space pxelinux;
+option pxelinux.magic code 208 = string;
+option pxelinux.configfile code 209 = text;
+option pxelinux.pathprefix code 210 = text;
+option pxelinux.reboottime code 211 = unsigned integer 32;
+option architecture-type code 93 = unsigned integer 16;
+
+subnet {{ dhcp.ipid }} netmask {{ dhcp.netmaskid }} {
+  interface {{ networkifacename }};
+
+  class "pxeclients" {
+    match if substring (option vendor-class-identifier, 0, 9) = "PXEClient";
+    next-server {{ helper.ipaddr }};
+
+    if option architecture-type = 00:07 {
+      filename "grub2/shimx64.efi";
+    } else {
+      # this is PXE specific  
+{% if ppc64le is sameas true %}
+      filename "boot/grub2/powerpc-ieee1275/core.elf";  
+{% else %}
+      filename "pxelinux.0";  
+{% endif %}
+    }
+  }
+
+  pool {
+    range {{ dhcp.poolstart }} {{ dhcp.poolend }};
+    # Static entries
 {% if bootstrap is defined %}
-		host {{ bootstrap.name | lower }} { hardware ethernet {{ bootstrap.macaddr }}; fixed-address {{ bootstrap.ipaddr }}; }
+    host {{ bootstrap.name | lower }} { hardware ethernet {{ bootstrap.macaddr }}; fixed-address {{ bootstrap.ipaddr }}; }
 {% endif %}
 {% for m in masters %}
-		host {{ m.name | lower }} { hardware ethernet {{ m.macaddr }}; fixed-address {{ m.ipaddr }}; }
+    host {{ m.name | lower }} { hardware ethernet {{ m.macaddr }}; fixed-address {{ m.ipaddr }}; }
 {% endfor %}
 {% if workers is defined %}
 {% for w in workers %}
-		host {{ w.name | lower }} { hardware ethernet {{ w.macaddr }}; fixed-address {{ w.ipaddr }}; }
+    host {{ w.name | lower }} { hardware ethernet {{ w.macaddr }}; fixed-address {{ w.ipaddr }}; }
 {% endfor %}
 {% endif %}
 {% if other is defined %}
 {% for o in other %}
-		host {{ o.name }} { hardware ethernet {{ o.macaddr }}; fixed-address {{ o.ipaddr }}; }
+    host {{ o.name }} { hardware ethernet {{ o.macaddr }}; fixed-address {{ o.ipaddr }}; }
 {% endfor %}
 {% endif %}
-		# this will not give out addresses to hosts not listed above
-		deny unknown-clients;
 
-		# this is PXE specific  
-{% if ppc64le is sameas true %}
-		filename "boot/grub2/powerpc-ieee1275/core.elf";  
-{% else %}
-		filename "pxelinux.0";  
-{% endif %}
-
-		next-server {{ helper.ipaddr }};
-     	}
+    # this will not give out addresses to hosts not listed above
+    deny unknown-clients;
+  }
 }

--- a/templates/grub2-bootstrap.j2
+++ b/templates/grub2-bootstrap.j2
@@ -1,0 +1,17 @@
+{% if bootstrap.ipaddr is defined and bootstrap.networkifacename is defined %}
+  {% set ipconfig = bootstrap.ipaddr + "::" + dhcp.router + ":" + dhcp.netmask + ":" + bootstrap.name + ":" + bootstrap.networkifacename + ":none" %}
+  {% set ipconfig = ipconfig + " nameserver=" + dns.forwarder1 %}
+  {% if dns.forwarder2 is defined %}
+    {% set ipconfig = ipconfig + " nameserver=" + dns.forwarder2 %}
+  {% endif %}
+{% else %}
+  {% set ipconfig = "dhcp" %}
+{% endif %}
+
+set default=0
+set timeout=10
+
+menuentry 'Install Bootstrap Node' {
+  linuxefi rhcos/kernel initrd=rhcos/initramfs.img nomodeset rd.neednet=1 ip={{ ipconfig }} coreos.inst=yes coreos.inst.install_dev={{ disk }} {% if "metal" in ocp_bios %} coreos.inst.image_url=http://{{ helper.ipaddr }}:8080/install/bios.raw.gz {% elif "rootfs" in ocp_bios %} coreos.live.rootfs_url=http://{{ helper.ipaddr }}:8080/install/rootfs.img {% else %} coreos.UNKNOWN.CONFIG=you_messed_up {% endif %} coreos.inst.ignition_url=http://{{ helper.ipaddr }}:8080/ignition/bootstrap.ign
+  initrdefi rhcos/initramfs.img
+}

--- a/templates/grub2-master.j2
+++ b/templates/grub2-master.j2
@@ -1,0 +1,17 @@
+{% if item.ipaddr is defined and item.networkifacename is defined %}
+  {% set ipconfig = item.ipaddr + "::" + dhcp.router + ":" + dhcp.netmask + ":" + item.name + ":" + item.networkifacename + ":none" %}
+  {% set ipconfig = ipconfig + " nameserver=" + dns.forwarder1 %}
+  {% if dns.forwarder2 is defined %}
+    {% set ipconfig = ipconfig + " nameserver=" + dns.forwarder2 %}
+  {% endif %}
+{% else %}
+  {% set ipconfig = "dhcp" %}
+{% endif %}
+
+set default=0
+set timeout=10
+
+menuentry 'Install Master Node' {
+  linuxefi rhcos/kernel initrd=rhcos/initramfs.img nomodeset rd.neednet=1 ip={{ ipconfig }} coreos.inst=yes coreos.inst.install_dev={{ disk }} {% if "metal" in ocp_bios %} coreos.inst.image_url=http://{{ helper.ipaddr }}:8080/install/bios.raw.gz {% elif "rootfs" in ocp_bios %} coreos.live.rootfs_url=http://{{ helper.ipaddr }}:8080/install/rootfs.img {% else %} coreos.UNKNOWN.CONFIG=you_messed_up {% endif %} coreos.inst.ignition_url=http://{{ helper.ipaddr }}:8080/ignition/master.ign
+  initrdefi rhcos/initramfs.img
+}

--- a/templates/grub2-worker.j2
+++ b/templates/grub2-worker.j2
@@ -1,0 +1,17 @@
+{% if item.ipaddr is defined and item.networkifacename is defined %}
+  {% set ipconfig = item.ipaddr + "::" + dhcp.router + ":" + dhcp.netmask + ":" + item.name + ":" + item.networkifacename + ":none" %}
+  {% set ipconfig = ipconfig + " nameserver=" + dns.forwarder1 %}
+  {% if dns.forwarder2 is defined %}
+    {% set ipconfig = ipconfig + " nameserver=" + dns.forwarder2 %}
+  {% endif %}
+{% else %}
+  {% set ipconfig = "dhcp" %}
+{% endif %}
+
+set default=0
+set timeout=10
+
+menuentry 'Install Worker Node' {
+  linuxefi rhcos/kernel initrd=rhcos/initramfs.img nomodeset rd.neednet=1 ip={{ ipconfig }} coreos.inst=yes coreos.inst.install_dev={{ disk }} {% if "metal" in ocp_bios %} coreos.inst.image_url=http://{{ helper.ipaddr }}:8080/install/bios.raw.gz {% elif "rootfs" in ocp_bios %} coreos.live.rootfs_url=http://{{ helper.ipaddr }}:8080/install/rootfs.img {% else %} coreos.UNKNOWN.CONFIG=you_messed_up {% endif %} coreos.inst.ignition_url=http://{{ helper.ipaddr }}:8080/ignition/worker.ign
+  initrdefi rhcos/initramfs.img
+}


### PR DESCRIPTION
main changes:

- added a block to create UEFI specifi files for tftpboot (main.yml)
- added templates for rending grub2 config files in tftboot
- install two addtional packages required for UEFI
  (shim-x64 and grub2-efi-x64)
- modified dhcpd.conf template
  - added options required for UEFI
  - cleanup of indention for better readability of rendered config

the rendered grub2 templates also support static ip address via ipaddr
and networkifacename (see also pull request #195 ).

this should fix issues #157 and #101.