### PR TITLE
fix for #197: update required packages for rhel 8

### DIFF
--- a/tasks/set_facts_.yaml
+++ b/tasks/set_facts_.yaml
@@ -79,6 +79,8 @@
         - python3-libselinux
         - podman
         - nfs-utils
+        - shim-x64
+        - grub2-efi-x64
   
   - set_fact:
       dhcppkgs:


### PR DESCRIPTION
shim-x64 and grub2-efi-x64 are required for rhel 7 and 8 to support
UEFI network boot.

seems like the packages have the same name and provide the same
files under rhel 7 and 8.