### PR TITLE
machineconfig_path

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 # defaults file
+machineconfig_path: ../machineconfig

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -473,7 +473,7 @@
     block:
     - name: Create folder for additional machineconfig
       file:
-        path: ../machineconfig
+        path: "{{ machineconfig_path }}"
         state: directory
 
     - name: Create temporary chrony.conf file
@@ -489,13 +489,13 @@
     - name: Generate Chrony machineconfig
       template:
         src: ../templates/chrony-machineconfig.j2
-        dest: ../machineconfig/99-{{item}}-chrony-configuration.yaml
+        dest: "{{ machineconfig_path }}"/99-{{item}}-chrony-configuration.yaml
       loop:
         - master
     - name: Generate Chrony machineconfig
       template:
         src: ../templates/chrony-machineconfig.j2
-        dest: ../machineconfig/99-{{item}}-chrony-configuration.yaml
+        dest: "{{ machineconfig_path }}"/99-{{item}}-chrony-configuration.yaml
       loop:
         - worker
       when:


### PR DESCRIPTION
Add the possibility to change the path where the additional machineconfig file (like chrony) will be generated.
The default (../machineconfig) as been preserved if no variable is specified.