### PR TITLE
Add Openshift Mirror Registry Automation 

### DIFF
--- a/docs/examples/vars-local-registry-ppc64le.yaml
+++ b/docs/examples/vars-local-registry-ppc64le.yaml
@@ -48,12 +48,27 @@ other:
 ppc64le: true
 setup_registry:
   deploy: true
+  use_mirror_registry: false
   autosync_registry: true
   registry_image: docker.io/ibmcom/registry-ppc64le:2.6.2.5
   local_repo: "ocp4/openshift4"
   product_repo: "openshift-release-dev"
   release_name: "ocp-release"
   release_tag: "4.4.9-ppc64le"
+
+mirror_registry_dir: "/opt/mirror-registry"
+quay_index_image: "quay.io/redhat-user-workloads/quay-eng-tenant/mirror-registry-v2-0@sha256:2a2683e79f4773553e17fe607332e33b1e52b52b84be66381f1944c8341a3054"
+local_copy_dir: "/tmp"
+force_reinstall: false
+registry_url: "brew.registry.redhat.io"
+registry_username: ""
+registry_password: ""
+init_password: "changeme"
+registry_hostname: "{{ ansible_fqdn }}"
+quay_storage_path: ""          
+sqlite_storage_path: ""         
+ssl_cert_path: ""              
+ssl_key_path: ""                
 
 ocp_bios: "https://mirror.openshift.com/pub/openshift-v4/ppc64le/dependencies/rhcos/4.3/4.3.18/rhcos-4.3.18-ppc64le-metal.ppc64le.raw.gz"
 ocp_initramfs: "https://mirror.openshift.com/pub/openshift-v4/ppc64le/dependencies/rhcos/4.3/4.3.18/rhcos-4.3.18-ppc64le-installer-initramfs.ppc64le.img"

--- a/docs/examples/vars-local-registry.yaml
+++ b/docs/examples/vars-local-registry.yaml
@@ -47,9 +47,26 @@ other:
 
 setup_registry:
   deploy: true
+  use_mirror_registry: false
   autosync_registry: true
   registry_image: docker.io/library/registry:2
   local_repo: "ocp4/openshift4"
   product_repo: "openshift-release-dev"
   release_name: "ocp-release"
   release_tag: "4.4.9-x86_64"
+
+# Mirror Registry specific variables (only used when use_mirror_registry: true)
+mirror_registry_dir: "/opt/mirror-registry"
+quay_index_image: "quay.io/redhat-user-workloads/quay-eng-tenant/mirror-registry-v2-0@sha256:2a2683e79f4773553e17fe607332e33b1e52b52b84be66381f1944c8341a3054"
+local_copy_dir: "/tmp"
+force_reinstall: false
+registry_url: "brew.registry.redhat.io"
+registry_username: ""  # Required for Mirror Registry
+registry_password: ""  # Required for Mirror Registry
+init_password: "changeme"  
+registry_hostname: "{{ ansible_fqdn }}"
+quay_storage_path: ""
+sqlite_storage_path: ""
+ssl_cert_path: ""
+ssl_key_path: ""
+

--- a/docs/vars-doc.md
+++ b/docs/vars-doc.md
@@ -316,6 +316,7 @@ In order to install a local registry on the helper node:
 ```
 setup_registry:
   deploy: false
+  use_mirror_registry: false
   autosync_registry: false
   registry_image: docker.io/library/registry:2
   local_repo: "ocp4/openshift4"
@@ -327,6 +328,7 @@ setup_registry:
 ```
 
 * `setup_registry.deploy` - Set this to true to enable registry installation.
+* `setup_registry.use_mirror_registry` - Set this to true to use Red Hat Mirror Registry (OMR).
 * `setup_registry.autosync_registry` - Set this to true to enable mirroring of installation images.
 * `setup_registry.registry_image` - This is the name of the image used for creating registry container.
 * `setup_registry.local_repo` - This is the name of the repo in your registry.
@@ -335,6 +337,92 @@ setup_registry:
 * `setup_registry.release_tag` - The version of OpenShift you want to sync.
 * `setup_registry.registry_user` - This is the registry username (default:admin).
 * `setup_registry.registry_password` - This is the registry password (default:admin).
+#### Mirror Registry Specific Variables
+
+When `use_mirror_registry` is set to `true`, the following additional variables are used:
+
+```
+mirror_registry_dir: "/opt/mirror-registry"
+quay_index_image: "quay.io/redhat-user-workloads/quay-eng-tenant/mirror-registry-v2-0@sha256:2a2683e79f4773553e17fe607332e33b1e52b52b84be66381f1944c8341a3054"
+local_copy_dir: "/tmp"
+force_reinstall: false
+registry_url: "brew.registry.redhat.io"
+registry_username: "rh-username"
+registry_password: "rh-password"
+init_password: "changeme"
+registry_hostname: "{{ ansible_fqdn }}"
+quay_storage_path: ""
+sqlite_storage_path: ""
+redis_storage_path: ""
+ssl_cert_path: ""
+ssl_key_path: ""
+```
+
+**Variable Descriptions:**
+
+* `mirror_registry_dir` - Directory where Mirror Registry will be installed (default: `/opt/mirror-registry`). This directory will contain the mirror-registry executable and related files.
+* `quay_index_image` - The Mirror Registry container image to pull from Red Hat. Uses a specific SHA256 digest for version pinning to ensure consistent deployments. Default points to Mirror Registry v2.0.
+* `local_copy_dir` - Temporary directory for extracting Mirror Registry tarball during installation (default: `/tmp`). The mirror-registry.tar.gz file will be copied here temporarily.
+* `force_reinstall` - Set to `true` to force reinstall of Mirror Registry (default: `false`). Checks for existing containers and cleans up before reinstalling.
+* `registry_url` - Red Hat registry URL for authentication to pull the Mirror Registry image (default: `brew.registry.redhat.io`). This is the registry where the mirror-registry container image is hosted.
+* `registry_username` - **REQUIRED** Your Red Hat registry username for authenticating to `registry_url`. This is needed to pull the Mirror Registry installation image.
+* `registry_password` - **REQUIRED** Your Red Hat registry password for authenticating to `registry_url`. This is needed to pull the Mirror Registry installation image.
+* `init_password` - Initial password for the Mirror Registry 'init' user (default: `changeme`). This is the admin password you'll use to login to the Quay web UI and API. **Should be changed for security!**
+* `registry_hostname` - Hostname/FQDN for the Mirror Registry (default: `{{ ansible_fqdn }}`). Uses the helper node's actual FQDN. This will be used as the hostname for accessing the Quay registry after installation.
+* `quay_storage_path` - **OPTIONAL** Custom path for Quay storage volume binding (default: empty). When set, mounts host directory to `/var/lib/quay` in container using `-v` flag. Example: `/data/quay`
+* `sqlite_storage_path` - **OPTIONAL** Custom path for PostgreSQL database storage (default: empty). When set, mounts host directory to `/var/lib/pgsql` in container using `-v` flag. Example: `/data/pgsql`
+* `redis_storage_path` - **OPTIONAL** Custom path for Redis data storage (default: empty). When set, mounts host directory to `/var/lib/redis` in container using `-v` flag. Example: `/data/redis`
+* `ssl_cert_path` - **OPTIONAL** Path to custom SSL certificate file (default: empty, uses self-signed). When set, uses `--sslCert` flag during installation. Example: `/etc/pki/tls/certs/registry.crt`
+* `ssl_key_path` - **OPTIONAL** Path to custom SSL key file (default: empty, uses self-signed). When set, uses `--sslKey` flag during installation. Example: `/etc/pki/tls/private/registry.key`
+
+**Important Notes:**
+
+1. **Authentication Required**: You must provide valid Red Hat credentials (`registry_username` and `registry_password`) to authenticate to `brew.registry.redhat.io` and pull the mirror-registry image.
+
+2. **Registry Access**: After installation, the Mirror Registry will be accessible at:
+   - Web UI: `https://<registry_hostname>:8443`
+   - Registry API: `https://<registry_hostname>:8443`
+   - Default user: `init`
+   - Password: Value of `init_password`
+
+3. **Firewall Ports**: The playbook automatically opens ports 8443 and 8080 for Mirror Registry access.
+
+4. **Security Best Practices**:
+   - Never commit credentials to version control
+   - Use Ansible Vault for sensitive data:
+     ```bash
+     ansible-vault encrypt_string 'your-password' --name 'registry_password'
+     ```
+   - Or pass credentials via command line:
+     ```bash
+     ansible-playbook -e @vars.yaml -e "registry_username=$RH_USERNAME" -e "registry_password=$RH_PASSWORD"
+     ```
+
+5. **Image Digest**: The `quay_index_image` uses a specific SHA256 digest to ensure consistent deployments. Update this value when upgrading to newer Mirror Registry versions.
+
+6. **Management Commands**: After installation, you can manage the Mirror Registry using:
+   ```bash
+   # Check status
+   /opt/mirror-registry/mirror-registry status
+   
+   # Stop the registry
+   /opt/mirror-registry/mirror-registry stop
+   
+   # Start the registry
+   /opt/mirror-registry/mirror-registry start
+   
+   # Restart the registry
+   /opt/mirror-registry/mirror-registry restart
+   
+   # Uninstall (with auto-approval)
+   /opt/mirror-registry/mirror-registry uninstall --autoApprove
+   ```
+
+7. **Troubleshooting**: If you encounter issues, check the container logs:
+   ```bash
+   podman logs quay-app
+   podman logs quay-postgres
+   podman logs quay-redis
 
 
 ### Running on Power

--- a/tasks/setup_registry.yaml
+++ b/tasks/setup_registry.yaml
@@ -1,206 +1,425 @@
 ---
-# tasks file for configure-local-registry
+# ============================================================================
+# OpenShift Registry Setup
+# Supports:
+# 1. Podman-based local registry
+# 2. OpenShift Mirror Registry
+# ============================================================================
 
-- name: Create registry directories
-  file:
-    path: /opt/registry/{{ item }}
-    state: directory
-  with_items:
-    - auth
-    - certs
-    - data
+# ============================================================================
+# DETERMINE REGISTRY TYPE
+# ============================================================================
+- name: Set registry type
+  set_fact:
+    use_mirror_registry: "{{ setup_registry.use_mirror_registry | default(false) }}"
 
-- name: Generate an OpenSSL private key with the default values (4096 bits, RSA)
-  run_once: true
-  openssl_privatekey:
-    path: /opt/registry/certs/domain.pem
+# ============================================================================
+# OPENSHIFT MIRROR REGISTRY INSTALLATION
+# ============================================================================
+- name: Install OpenShift Mirror Registry
+  when: use_mirror_registry | bool
+  block:
+    - name: Login to podman
+      command: >
+        podman login {{ registry_url }} -u {{ registry_username }} --password-stdin
+      args:
+        stdin: "{{ registry_password }}"
+      register: podman_login
+      no_log: true
+      changed_when: "'Login Succeeded!' in podman_login.stdout"
+      failed_when: "'Login Succeeded!' not in podman_login.stdout"
+    
+    - name: Check for containers from previous mirror-registry deployment
+      shell: podman ps -a --filter "name=quay" --format "{% raw %}{{.Names}}{% endraw %}"
+      register: mirror_registry_containers
+      failed_when: false
+      changed_when: false
 
-- name: Generate an OpenSSL Certificate Signing Request
-  run_once: true
-  openssl_csr:
-    path: /opt/registry/certs/domain.csr
-    privatekey_path: /opt/registry/certs/domain.pem
-    basic_constraints:
-      - CA:TRUE
-    basic_constraints_critical: yes
-    common_name: "{{ registry_host }}"
+    - name: Check if mirror registry is already installed
+      stat:
+        path: "{{ mirror_registry_dir }}/mirror-registry"
+      register: mirror_registry_exists
 
-- name: Generate a Self Signed OpenSSL certificate
-  run_once: true
-  openssl_certificate:
-    path: /opt/registry/certs/domain.crt
-    privatekey_path: /opt/registry/certs/domain.pem
-    csr_path: /opt/registry/certs/domain.csr
-    provider: selfsigned
+    - name: Uninstall existing mirror registry if reinstalling
+      shell: |
+        if [ -x "{{ mirror_registry_dir }}/mirror-registry" ]; then
+          "{{ mirror_registry_dir }}/mirror-registry" uninstall --autoApprove
+        fi
+      become: yes
+      register: uninstall_result
+      failed_when: false
+      changed_when: uninstall_result.rc == 0
+      when:
+        - (mirror_registry_exists.stat.exists or mirror_registry_containers.stdout != "")
+        - force_reinstall | default(false)
 
-- name: Create the user and password for local registry
-  run_once: true
-  shell: htpasswd -bBc /opt/registry/auth/htpasswd {{ setup_registry.registry_user | default('admin') }} {{ setup_registry.registry_password | default('admin') }}
-  args:
-    creates: /opt/registry/auth/htpasswd
+    - name: Remove old mirror-registry path before re-installing
+      file:
+        path: "{{ mirror_registry_dir }}"
+        state: absent
+      become: yes
+      when:
+        - mirror_registry_exists.stat.exists
+        - force_reinstall | default(false)
 
-- name: Synchronize directories across all hosts
-  synchronize:
-    src: "{{ item }}"
-    dest: "{{ item }}"
-    recursive: yes
-  delegate_to: "{{ ansible_play_batch[0] }}"
-  with_items:
-    - /opt/registry/
-    - ~/.openshift/
-  when: high_availability is defined
+    - name: Pull mirror registry image
+      shell: podman pull {{ quay_index_image }}
+      register: podman_pull
+      retries: 3
+      delay: 10
+      until: podman_pull.rc == 0
 
-- name: Copy Self Signed OpenSSL certificate
-  copy:
-    src: /opt/registry/certs/domain.crt
-    dest: /etc/pki/ca-trust/source/anchors/domain.crt
-    remote_src: yes
-    force: yes
+    - name: Create mirror registry directory
+      file:
+        path: "{{ mirror_registry_dir }}"
+        state: directory
+        mode: '0755'
+      become: yes
 
-- name: Add the Self Signed OpenSSL certificate to your list of trusted certificates
-  shell: |
-    update-ca-trust || true
-    cat /etc/pki/tls/certs/ca-bundle.trust.crt | grep {{ registry_host }} | wc -l
-  register: cert_trust
-  until: cert_trust.stdout|int == 1
-  retries: 3
-  delay: 10
+    - name: Copy mirror registry from container
+      shell: |
+        container_id=$(podman create {{ quay_index_image }})
+        podman cp $container_id:/mirror-registry.tar.gz {{ local_copy_dir }}/mirror-registry.tar.gz
+        podman rm $container_id
+      args:
+        creates: "{{ local_copy_dir }}/mirror-registry.tar.gz"
 
-- name: Generate local-registry service file
-  template:
-    src: ../templates/local-registry.service.j2
-    dest: /etc/systemd/system/local-registry.service
-    mode: 0655
+    - name: Extract the mirror registry
+      unarchive:
+        src: "{{ local_copy_dir }}/mirror-registry.tar.gz"
+        dest: "{{ mirror_registry_dir }}"
+        remote_src: yes
+        creates: "{{ mirror_registry_dir }}/mirror-registry"
+      become: yes
 
-- name: Start local-registry
-  systemd:
-    name: local-registry
-    state: started
-    enabled: yes
-    daemon_reload: yes
+    - name: Make mirror-registry binary executable
+      file:
+        path: "{{ mirror_registry_dir }}/mirror-registry"
+        mode: '0755'
+      become: yes
 
-- name: Ensure registry pod is up
-  shell: podman ps | grep local-registry
-  register: pod_state
-  until: pod_state.stdout != ""
-  retries: 4
-  delay: 15
+    - name: Install mirror registry
+      shell: |
+        "{{ mirror_registry_dir }}/mirror-registry" install \
+          --initPassword="{{ init_password }}" \
+          --quayHostname="{{ registry_hostname }}"{% if quay_storage_path != "" %} \
+          -v "{{ quay_storage_path }}:/var/lib/quay:Z"{% endif %}{% if sqlite_storage_path != "" %} \
+          -v "{{ sqlite_storage_path }}:/var/lib/pgsql:Z"{% endif %}{% if redis_storage_path != "" %} \
+          -v "{{ redis_storage_path }}:/var/lib/redis:Z"{% endif %}{% if ssl_cert_path != "" %} \
+          --sslCert="{{ ssl_cert_path }}"{% endif %}{% if ssl_key_path != "" %} \
+          --sslKey="{{ ssl_key_path }}"{% endif %}
+      register: install_result
+      become: yes
+      when: not mirror_registry_exists.stat.exists or force_reinstall | default(false)
 
-- name: Allow traffic at local registry port
-  firewalld:
-    port: 5000/tcp
-    permanent: yes
-    zone: "{{ item }}"
-    state: enabled
-  with_items:
-  - internal
-  - public
+    - name: Wait for mirror registry to be operational
+      uri:
+        url: "https://{{ registry_hostname }}:8443/health/instance"
+        method: GET
+        validate_certs: no
+        status_code: 200
+      register: health_check
+      until: health_check.status == 200
+      retries: 10
+      delay: 15
 
-- name: Restarting registry services
-  service:
-    name: "{{ item }}"
-    state: restarted
-  with_items:
-    - "{{ registry_services }}"
+    - name: Configure firewall for mirror registry
+      firewalld:
+        port: "{{ item }}/tcp"
+        permanent: yes
+        state: enabled
+        immediate: yes
+      loop:
+        - 8443
+        - 8080
 
-- name: Get local registry pod
-  shell: curl -u {{ setup_registry.registry_user | default('admin') }}:{{ setup_registry.registry_password | default('admin') }} -k https://{{ local_registry }}/v2/_catalog | grep repositories
-  register: pod_state
-  until: pod_state.stdout != ""
-  retries: 3
-  delay: 30
+    - name: Display mirror registry completion
+      debug:
+        msg:
+          - "OpenShift Mirror Registry installed successfully"
+          - "URL: https://{{ registry_hostname }}:8443"
+          - "Username: init"
+          - "Password: {{ init_password }}"
+
+# ============================================================================
+# PODMAN-BASED LOCAL REGISTRY INSTALLATION
+# ============================================================================
+- name: Install Podman-based Local Registry
+  when: not use_mirror_registry | bool
+  block:
+    - name: Create registry directories
+      file:
+        path: /opt/registry/{{ item }}
+        state: directory
+      with_items:
+        - auth
+        - certs
+        - data
+
+    - name: Generate an OpenSSL private key with the default values (4096 bits, RSA)
+      run_once: true
+      openssl_privatekey:
+        path: /opt/registry/certs/domain.pem
+
+    - name: Generate an OpenSSL Certificate Signing Request
+      run_once: true
+      openssl_csr:
+        path: /opt/registry/certs/domain.csr
+        privatekey_path: /opt/registry/certs/domain.pem
+        basic_constraints:
+          - CA:TRUE
+        basic_constraints_critical: yes
+        common_name: "{{ registry_host }}"
+
+    - name: Generate a Self Signed OpenSSL certificate
+      run_once: true
+      openssl_certificate:
+        path: /opt/registry/certs/domain.crt
+        privatekey_path: /opt/registry/certs/domain.pem
+        csr_path: /opt/registry/certs/domain.csr
+        provider: selfsigned
+
+    - name: Create the user and password for local registry
+      run_once: true
+      shell: htpasswd -bBc /opt/registry/auth/htpasswd {{ setup_registry.registry_user | default('admin') }} {{ setup_registry.registry_password | default('admin') }}
+      args:
+        creates: /opt/registry/auth/htpasswd
+
+    - name: Synchronize directories across all hosts
+      synchronize:
+        src: "{{ item }}"
+        dest: "{{ item }}"
+        recursive: yes
+      delegate_to: "{{ ansible_play_batch[0] }}"
+      with_items:
+        - /opt/registry/
+        - ~/.openshift/
+      when: high_availability is defined
+
+    - name: Copy Self Signed OpenSSL certificate
+      copy:
+        src: /opt/registry/certs/domain.crt
+        dest: /etc/pki/ca-trust/source/anchors/domain.crt
+        remote_src: yes
+        force: yes
+
+    - name: Add the Self Signed OpenSSL certificate to your list of trusted certificates
+      shell: |
+        update-ca-trust || true
+        cat /etc/pki/tls/certs/ca-bundle.trust.crt | grep {{ registry_host }} | wc -l
+      register: cert_trust
+      until: cert_trust.stdout|int == 1
+      retries: 3
+      delay: 10
+
+    - name: Generate local-registry service file
+      template:
+        src: ../templates/local-registry.service.j2
+        dest: /etc/systemd/system/local-registry.service
+        mode: 0655
+
+    - name: Start local-registry
+      systemd:
+        name: local-registry
+        state: started
+        enabled: yes
+        daemon_reload: yes
+
+    - name: Ensure registry pod is up
+      shell: podman ps | grep local-registry
+      register: pod_state
+      until: pod_state.stdout != ""
+      retries: 4
+      delay: 15
+
+    - name: Allow traffic at local registry port
+      firewalld:
+        port: 5000/tcp
+        permanent: yes
+        zone: "{{ item }}"
+        state: enabled
+      with_items:
+        - internal
+        - public
+
+    - name: Restarting registry services
+      service:
+        name: "{{ item }}"
+        state: restarted
+      with_items:
+        - "{{ registry_services }}"
+
+    - name: Get local registry pod
+      shell: curl -u {{ setup_registry.registry_user | default('admin') }}:{{ setup_registry.registry_password | default('admin') }} -k https://{{ local_registry }}/v2/_catalog | grep repositories
+      register: pod_state
+      until: pod_state.stdout != ""
+      retries: 3
+      delay: 30
+
+    - name: Display local registry completion
+      debug:
+        msg:
+          - "Podman-based Local Registry installed successfully"
+          - "URL: https://{{ local_registry }}"
+          - "Username: {{ setup_registry.registry_user | default('admin') }}"
+
+# ============================================================================
+# SHARED PULL SECRET CONFIGURATION
+# ============================================================================
+- name: Set registry URL for pull secret
+  set_fact:
+    registry_url_for_secret: "{{ registry_hostname + ':8443' if use_mirror_registry | bool else local_registry }}"
 
 - name: Mirror the registry
-  when: pod_state.stdout != ""
+  when: use_mirror_registry | bool or pod_state.stdout != ""
   block:
-  - name: Generate the base64-encoded user name and password or token for your mirror registry
-    shell: |
-      registry_token=`echo -n "{{ setup_registry.registry_user  | default('admin') }}:{{ setup_registry.registry_password | default('admin') }}" | base64 -w0`
-      jq '.auths += {"{{ local_registry }}": {"auth": "'$registry_token'","email": "noemail@localhost"}}' < ~/.openshift/pull-secret > ~/.openshift/pull-secret-updated
-    args:
-      creates: ~/.openshift/pull-secret-updated
+    - name: Generate the base64-encoded user name and password or token for your mirror registry
+      shell: |
+        {% if use_mirror_registry | bool %}
+        registry_token=`echo -n "init:{{ init_password }}" | base64 -w0`
+        {% else %}
+        registry_token=`echo -n "{{ setup_registry.registry_user | default('admin') }}:{{ setup_registry.registry_password | default('admin') }}" | base64 -w0`
+        {% endif %}
+        jq '.auths += {"{{ registry_url_for_secret }}": {"auth": "'$registry_token'","email": "noemail@localhost"}}' < ~/.openshift/pull-secret > ~/.openshift/pull-secret-updated
+      args:
+        creates: ~/.openshift/pull-secret-updated
 
-  - name: Retrieve the Release Image Manifest
-    shell: |
-      oc adm release info {{ release_image }} -o json
-    register: release_manifest
+    - name: Retrieve the Release Image Manifest
+      shell: |
+        oc adm release info {{ release_image }} -o json
+      register: release_manifest
 
-  - name: Query for the OCP Version from Release Image Manifest
-    shell: |
-      echo '{{ release_manifest.stdout }}' | jq -r '.' | jq -r '.config.config.Labels["io.openshift.release"]'
-    register: release_version
+    - name: Query for the OCP Version from Release Image Manifest
+      shell: |
+        echo '{{ release_manifest.stdout }}' | jq -r '.' | jq -r '.config.config.Labels["io.openshift.release"]'
+      register: release_version
 
-  - name: Register the MAJOR, MINOR for the ocp_version
-    shell: |
-      echo "{{ release_version.stdout }}" | tr '.' ' ' | awk '{print $1, $2}'
-    register: ocp_version
+    - name: Register the MAJOR, MINOR for the ocp_version
+      shell: |
+        echo "{{ release_version.stdout }}" | tr '.' ' ' | awk '{print $1, $2}'
+      register: ocp_version
 
-  - name: Check if image manifest is having Multi payload. 
-    shell: |
-      echo '{{ release_manifest.stdout }}' | jq -r '.metadata.metadata | ."release.openshift.io/architecture"?'
-    register: multi_payload
-  
-  - name: Check if image manifest is having Single payload.
-    shell: |
-      RELEASE_DIGEST=$(oc image info --output=json -a ~/.openshift/pull-secret-updated {{ release_image }} | grep -c "Digest" )
-      echo $RELEASE_DIGEST
-    register: single_payload
+    - name: Check if image manifest is having Multi payload.
+      shell: |
+        echo '{{ release_manifest.stdout }}' | jq -r '.metadata.metadata | ."release.openshift.io/architecture"?'
+      register: multi_payload
 
-  - name: Mirroring with multi arch payload 
-    shell: |
-      for DIGEST in $(oc image info --output=json -a ~/.openshift/pull-secret-updated {{ release_image }} 2>&1 | grep linux | awk '{print $NF}')
-      do
-        SIGFILE=$(echo $DIGEST | sed 's/:/-/g').sig
-        oc image mirror -a ~/.openshift/pull-secret-updated \
-          {{ setup_registry.remote_registry | default('quay.io') }}/{{ setup_registry.product_repo }}/{{ setup_registry.release_name }}:${SIGFILE} \ 
-          {{ local_registry }}/{{ setup_registry.local_repo }}:${SIGFILE} \
-          --force=false
-      done
-    register: multi_out
-    when:
-      - setup_registry.autosync_registry
-      - multi_payload.stdout == "multi"
-      - (((ocp_version.stdout.split(' ')[0] | int ) >= 4 and (ocp_version.stdout.split(' ')[1] | int) > 18 ) or ( (ocp_version.stdout.split(' ')[0] | int ) >= 5 ))
+    - name: Check if image manifest is having Single payload.
+      shell: |
+        RELEASE_DIGEST=$(oc image info --output=json -a ~/.openshift/pull-secret-updated {{ release_image }} | grep -c "Digest" )
+        echo $RELEASE_DIGEST
+      register: single_payload
 
-  - name: Mirroring with single arch payload
-    shell: |
-      CONTENT_DIGEST=$(oc image info --output=json -a ~/.openshift/pull-secret-updated {{ release_image }} \
-        | jq -r '.contentDigest | split(":")[1]' )
-      oc image mirror \
-        -a ~/.openshift/pull-secret-updated \
-        {{ setup_registry.remote_registry | default('quay.io') }}/{{ setup_registry.product_repo }}/{{ setup_registry.release_name }}:sha256-$CONTENT_DIGEST.sig \
-        {{ local_registry }}/{{ setup_registry.local_repo }}:sha256-$CONTENT_DIGEST.sig \
-        --force=false
-    register: single_payload
-    when:
-      - setup_registry.autosync_registry
-      - single_payload is defined
-      - single_payload.stdout | trim | int != 0
-      - (((ocp_version.stdout.split(' ')[0] | int ) >= 4 and (ocp_version.stdout.split(' ')[1] | int) > 18 ) or ((ocp_version.stdout.split(' ')[0] | int ) >= 5 ))
+    - name: Mirroring with multi arch payload
+      shell: |
+        for DIGEST in $(oc image info --output=json -a ~/.openshift/pull-secret-updated {{ release_image }} 2>&1 | grep linux | awk '{print $NF}')
+        do
+          SIGFILE=$(echo $DIGEST | sed 's/:/-/g').sig
+          oc image mirror -a ~/.openshift/pull-secret-updated \
+            {{ setup_registry.remote_registry | default('quay.io') }}/{{ setup_registry.product_repo }}/{{ setup_registry.release_name }}:${SIGFILE} \
+            {{ registry_url_for_secret }}/{{ setup_registry.local_repo }}:${SIGFILE} \
+            --force=false {% if use_mirror_registry | bool %}--insecure=true{% endif %}
+        done
+      register: multi_out
+      when:
+        - setup_registry.autosync_registry
+        - multi_payload.stdout == "multi"
+        - (((ocp_version.stdout.split(' ')[0] | int ) >= 4 and (ocp_version.stdout.split(' ')[1] | int) > 18 ) or ((ocp_version.stdout.split(' ')[0] | int ) >= 5 ))
 
-  - name: Mirror the registry
-    when: setup_registry.autosync_registry
-    shell: oc adm -a ~/.openshift/pull-secret-updated release mirror \
-      --from={{ release_image }} \
-      --to={{ local_registry }}/{{ setup_registry.local_repo }} \
-      --to-release-image={{ local_registry }}/{{ setup_registry.local_repo }}:{{ setup_registry.release_tag }}
-    register: registry
+    - name: Mirroring with single arch payload
+      shell: |
+        CONTENT_DIGEST=$(oc image info --output=json -a ~/.openshift/pull-secret-updated {{ release_image }} \
+          | jq -r '.contentDigest | split(":")[1]' )
+        oc image mirror \
+          -a ~/.openshift/pull-secret-updated \
+          {{ setup_registry.remote_registry | default('quay.io') }}/{{ setup_registry.product_repo }}/{{ setup_registry.release_name }}:sha256-$CONTENT_DIGEST.sig \
+          {{ registry_url_for_secret }}/{{ setup_registry.local_repo }}:sha256-$CONTENT_DIGEST.sig \
+          --force=false {% if use_mirror_registry | bool %}--insecure=true{% endif %}
+      register: single_payload_result
+      when:
+        - setup_registry.autosync_registry
+        - single_payload is defined
+        - single_payload.stdout | trim | int != 0
+        - (((ocp_version.stdout.split(' ')[0] | int ) >= 4 and (ocp_version.stdout.split(' ')[1] | int) > 18 ) or ((ocp_version.stdout.split(' ')[0] | int ) >= 5 ))
 
-  - name: Generate Local Registry information
-    when: setup_registry.autosync_registry
-    copy:
-      content: "{{ registry.stdout }}"
-      dest: ../postrun-local-registry-info
+    - name: Mirror the registry
+      when: setup_registry.autosync_registry
+      shell: |
+        oc adm -a ~/.openshift/pull-secret-updated release mirror \
+          --from={{ release_image }} \
+          --to={{ registry_url_for_secret }}/{{ setup_registry.local_repo }} \
+          --to-release-image={{ registry_url_for_secret }}/{{ setup_registry.local_repo }}:{{ setup_registry.release_tag }} \
+          {% if use_mirror_registry | bool %}--insecure=true{% endif %}
+      register: registry
 
-  - name: Process Local Registry information
-    when: setup_registry.autosync_registry
-    shell: "sed -i '1,/Success/d' ../postrun-local-registry-info"
+    - name: Generate Local Registry information
+      when: setup_registry.autosync_registry
+      copy:
+        content: "{{ registry.stdout }}"
+        dest: ../postrun-local-registry-info
 
-  - name: Mirror NFS image (x86_64)
-    when: setup_registry.autosync_registry and not ppc64le
-    shell: |
-      oc image mirror quay.io/external_storage/nfs-client-provisioner:latest registry.{{ dns.clusterid }}.{{ dns.domain }}:5000/nfs-client-provisioner:latest -a ~/.openshift/pull-secret-updated
+    - name: Process Local Registry information
+      when: setup_registry.autosync_registry
+      shell: "sed -i '1,/Success/d' ../postrun-local-registry-info"
 
-  - name: Mirror NFS image (ppc64le)
-    when: setup_registry.autosync_registry and ppc64le
-    shell: "oc image mirror registry.k8s.io/sig-storage/nfs-subdir-external-provisioner:v4.0.2 registry.{{ dns.clusterid }}.{{ dns.domain }}:5000/nfs-client-provisioner:latest -a ~/.openshift/pull-secret-updated"
+    - name: Mirror NFS image (x86_64)
+      when: setup_registry.autosync_registry and not ppc64le
+      shell: |
+        oc image mirror quay.io/external_storage/nfs-client-provisioner:latest {{ registry_url_for_secret }}/nfs-client-provisioner:latest -a ~/.openshift/pull-secret-updated {% if use_mirror_registry | bool %}--insecure=true{% endif %}
+
+    - name: Mirror NFS image (ppc64le)
+      when: setup_registry.autosync_registry and ppc64le
+      shell: |
+        oc image mirror registry.k8s.io/sig-storage/nfs-subdir-external-provisioner:v4.0.2 {{ registry_url_for_secret }}/nfs-client-provisioner:latest -a ~/.openshift/pull-secret-updated {% if use_mirror_registry | bool %}--insecure=true{% endif %}
+
+# ============================================================================
+# POST-INSTALLATION INFORMATION
+# ============================================================================
+- name: Create registry information file
+  copy:
+    content: |
+      # Registry Installation Information
+
+      ## Registry Type
+      {{ 'OpenShift Mirror Registry' if use_mirror_registry | bool else 'Podman-based Local Registry' }}
+
+      ## Access Details
+      - Registry URL: {{ 'https://' + registry_hostname + ':8443' if use_mirror_registry | bool else 'https://' + local_registry }}
+      - Username: {{ 'init' if use_mirror_registry | bool else setup_registry.registry_user | default('admin') }}
+      - Pull Secret: ~/.openshift/pull-secret-updated
+
+      ## Management Commands
+      {% if use_mirror_registry | bool %}
+      ```bash
+      {{ mirror_registry_dir }}/mirror-registry status
+      {{ mirror_registry_dir }}/mirror-registry stop
+      {{ mirror_registry_dir }}/mirror-registry start
+      {{ mirror_registry_dir }}/mirror-registry restart
+      ```
+      {% else %}
+      ```bash
+      systemctl status local-registry
+      systemctl restart local-registry
+      podman logs local-registry
+      ```
+      {% endif %}
+
+      ## Using with OpenShift
+      ```yaml
+      pullSecret: '$(cat ~/.openshift/pull-secret-updated | jq -c .)'
+      ```
+    dest: ../REGISTRY-INFO.md
+    mode: '0644'
+
+- name: Display setup completion message
+  debug:
+    msg:
+      - "============================================"
+      - "Registry Setup Complete!"
+      - "============================================"
+      - "Type: {{ 'OpenShift Mirror Registry' if use_mirror_registry | bool else 'Podman Local Registry' }}"
+      - "URL: {{ 'https://' + registry_hostname + ':8443' if use_mirror_registry | bool else 'https://' + local_registry }}"
+      - "Pull Secret: ~/.openshift/pull-secret-updated"
+      - "Documentation: ../REGISTRY-INFO.md"
+      - "============================================"
+

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -19,6 +19,7 @@ chronyconfig:
   enabled: false
 setup_registry:
   deploy: false
+  use_mirror_registry: false
   autosync_registry: false
   registry_image: docker.io/library/registry:3
   local_repo: "ocp4/openshift4"
@@ -30,6 +31,21 @@ setup_registry:
   ocp_channel_name: "stable-4.20"
   ocp_min_version: "4.20.2"
   ocp_max_version: "4.20.2"
+# Mirror Registry specific variables (used when use_mirror_registry: true)
+mirror_registry_dir: "/opt/mirror-registry"
+quay_index_image: "quay.io/redhat-user-workloads/quay-eng-tenant/mirror-registry-v2-0@sha256:2a2683e79f4773553e17fe607332e33b1e52b52b84be66381f1944c8341a3054"
+local_copy_dir: "/tmp"
+force_reinstall: false
+registry_url: "brew.registry.redhat.io"
+registry_username: ""
+registry_password: ""
+init_password: "changeme"
+registry_hostname: "{{ ansible_fqdn }}"
+quay_storage_path: ""           
+sqlite_storage_path: ""        
+redis_storage_path: ""       
+ssl_cert_path: ""               
+ssl_key_path: ""
 machineconfig_path: ../machineconfig
 fips: false
 secure_named: false


### PR DESCRIPTION
This PR adds automation for OpenShift Mirror Registry installation in setup_registry while preserving support for the existing Podman-based local registry.

It includes the Mirror Registry installation flow, updates pull-secret creation and release mirroring for both registry options, adds the required variables in vars/main.yml, and documents the configuration in docs/vars-doc.md.