### PR TITLE
Add RHEL 10 DHCP support updates

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -20,6 +20,11 @@
     name: dhcpd
     state: restarted
 
+- name: restart kea-dhcp4
+  service:
+    name: kea-dhcp4.service
+    state: restarted
+
 - name: restart tftp
   service:
     name: tftp

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -59,7 +59,15 @@
       dest: /etc/dhcp/dhcpd.conf
     notify:
       - restart dhcpd
-    when: not staticips and not uefi
+    when: not staticips and not uefi and ansible_distribution_major_version | int < 10
+
+  - name: Write out dhcp file for RHEL 10 and above
+    template:
+      src: ../templates/kea-dhcp4.conf.j2
+      dest: /etc/kea/kea-dhcp4.conf
+    notify:
+      - restart kea-dhcp4
+    when: not staticips and not uefi and ansible_distribution_major_version | int >= 10
 
   - name: Write out dhcp file (UEFI)
     template:
@@ -67,7 +75,15 @@
       dest: /etc/dhcp/dhcpd.conf
     notify:
       - restart dhcpd
-    when: not staticips and uefi
+    when: not staticips and uefi and ansible_distribution_major_version | int < 10
+  
+  - name: Write out dhcp file (UEFI) for RHEL 10 and above
+    template:
+      src: ../templates/kea-dhcp4.conf.j2
+      dest: /etc/kea/kea-dhcp4.conf
+    notify:
+      - restart kea-dhcp4
+    when: not staticips and uefi and ansible_distribution_major_version | int >= 10
 
   - name: Setup named configuration files
     block:
@@ -431,25 +447,33 @@
     with_items:
       - "{{ services }}"
 
-  - name: Starting DHCP/PXE services for baremetal
+  - name: Starting PXE services for baremetal
     service:
       name: "{{ item }}"
       enabled: yes
       state: started
     with_items:
-      - dhcpd
       - tftp
       - helper-tftp
     when: not staticips and baremetal
 
-  - name: Starting DHCP/PXE services
+  - name: Starting DHCP services
     service:
       name: "{{ item }}"
       enabled: yes
       state: started
     with_items:
       - dhcpd
-    when: not staticips and not baremetal
+    when: not staticips and ansible_distribution_major_version | int < 10
+
+  - name: Starting DHCP services for RHEL 10 and above
+    service:
+      name: "{{ item }}"
+      enabled: yes
+      state: started
+    with_items:
+      - kea-dhcp4
+    when: not staticips and ansible_distribution_major_version | int >= 10
 
   - name: Unmasking Services
     systemd:

--- a/tasks/remove_old_config_files.yaml
+++ b/tasks/remove_old_config_files.yaml
@@ -2,6 +2,13 @@
   file:
     path: /etc/dhcp/dhcpd.conf
     state: absent
+#  when: ansible_distribution_major_version | int < 10
+
+- name: Remove existing dhcp config for RHEL10 and above
+  file:
+    path: /etc/kea/kea-dhcp4.conf
+    state: absent
+  when: ansible_distribution_major_version | int >= 10
 
 - name: Remove existing named config
   file:

--- a/tasks/set_facts_.yaml
+++ b/tasks/set_facts_.yaml
@@ -18,7 +18,12 @@
 - block:
   - set_fact:
       critical_services: "{{ critical_services + [ 'dhcpd' ] }}"
-  when: not staticips
+  when: not staticips and ansible_distribution_major_version | int < 10
+
+- block:
+  - set_fact:
+      critical_services: "{{ critical_services + [ 'kea-dhcp4' ] }}"
+  when: not staticips and ansible_distribution_major_version | int >= 10
 
 - block:
   - set_fact:

--- a/templates/kea-dhcp4.conf.j2
+++ b/templates/kea-dhcp4.conf.j2
@@ -1,0 +1,129 @@
+{
+    "Dhcp4": {
+        "authoritative": true,
+        "valid-lifetime": 14400,
+        "max-valid-lifetime": 14400,
+        "interfaces-config": {
+            "interfaces": [ "{{ networkifacename }}" ]
+        },
+        "lease-database": {
+            "type": "memfile",
+            "lfc-interval": 3600
+        },
+
+        "option-data": [
+            { 
+                "name": "routers", 
+                "data": "{{ dhcp.router }}" 
+            },
+            { 
+                "name": "broadcast-address", 
+                "data": "{{ dhcp.bcast }}" 
+            },
+            { 
+                "name": "subnet-mask", 
+                "data": "{{ dhcp.netmask }}" 
+            },
+
+{% if dhcp.dns is defined and dhcp.dns != "" %}
+            { 
+                "name": "domain-name-servers", 
+                "data": "{{ dhcp.dns }}" 
+            },
+            { 
+                "name": "domain-search", 
+                "data": "{{ dns.clusterid }}.{{ dns.domain | lower }}", "{{ dns.domain | lower }}" 
+            },
+{% else %}
+            { 
+                "name": "domain-name-servers", 
+                "data": "{{ helper.ipaddr }}" 
+            },
+{% endif %}
+            
+{# This is PXE specific #}
+{% if ppc64le is sameas true %}
+            { 
+                "name": "boot-file-name", 
+                "data": "boot/grub2/powerpc-ieee1275/core.elf" 
+            },
+{% else %}
+            { 
+                "name": "boot-file-name", 
+                "data": "pxelinux.0" 
+            },
+{% endif %}
+
+            { 
+                "name": "domain-name", 
+                "data": "{{ dns.clusterid }}.{{ dns.domain | lower }}" 
+            }
+
+        ],
+        "host-reservation-identifiers": [ "hw-address" ],
+
+        "subnet4": [
+            {
+                "id": 1,
+
+{% set ns = namespace(prefix=0) %}
+    {% set bits = { '0': 0, '128': 1, '192': 2, '224': 3, '240': 4, '248': 5, '252': 6, '254': 7, '255': 8 } %}
+{% for octet in dhcp.netmask.split('.') %}
+{% set ns.prefix = ns.prefix + bits[octet] %}
+{% endfor %}
+
+                "subnet": "{{ dhcp.ipid }}/{{ ns.prefix }}",
+                "interface": "{{ networkifacename }}", 
+                "next-server": "{{ helper.ipaddr }}",
+                "pools" :[
+                    {
+                        "pool": "{{ dhcp.poolstart }} - {{ dhcp.poolend }}",
+                        "client-class": "KNOWN"
+                    }
+                ],
+
+                "reservations": [
+{% if not ipi %}
+{# Static entries #}
+  {% if bootstrap is defined %}
+                    { 
+                        "hostname": "{{ bootstrap.name | lower }}", 
+                        "hw-address": "{{ bootstrap.macaddr }}", 
+                        "ip-address": "{{ bootstrap.ipaddr }}" 
+                    }{% if masters or workers is defined or other is defined %},{% endif %}
+  {% endif %}
+
+  {% for m in masters %}
+                    { 
+                        "hostname": "{{ m.name | lower }}", 
+                        "hw-address": "{{ m.macaddr }}", 
+                        "ip-address": "{{ m.ipaddr }}" 
+                    }{% if not loop.last or workers is defined or other is defined %},{% endif %}
+  {% endfor %}
+
+  {% if workers is defined %}
+    {% for w in workers %}
+                    { 
+                        "hostname": "{{ w.name | lower }}", 
+                        "hw-address": "{{ w.macaddr }}", 
+                        "ip-address": "{{ w.ipaddr }}" 
+                    }{% if not loop.last or other is defined %},{% endif %}
+    {% endfor %}
+  {% endif %}
+{% endif %}
+
+{% if other is defined %}
+  {% for o in other %}
+                    { 
+                        "hostname": "{{ o.name }}", 
+                        "hw-address": "{{ o.macaddr }}", 
+                        "ip-address": "{{ o.ipaddr }}" 
+                    }{% if not loop.last %},{% endif %}
+  {% endfor %}
+{% endif %}
+                ]
+                
+            }
+        ]
+    }
+}

--- a/templates/named.conf.j2
+++ b/templates/named.conf.j2
@@ -35,8 +35,11 @@ options {
 	/* Fowarders */
 	forward only;
 	forwarders { {{ dns.forwarder1 | default("8.8.8.8") }}; {{ dns.forwarder2 | default("8.8.4.4") }}; };
-
+	
+	{% if ansible_facts['distribution_major_version'] | int < 10 %}
 	dnssec-enable yes;
+	{% endif %}
+
 	dnssec-validation no;
 
 	managed-keys-directory "/var/named/dynamic";


### PR DESCRIPTION
Changes made for *[OPENSHIFTP-754](https://jsw.ibm.com/browse/OPENSHIFTP-754)*: OCP Automation: Support RHEL10/CentOS10

- update DHCP package handling and migration to kea-dhcp4 for RHEL 10 and above
- Create jinja template file for kea-dhcp4 configuration

Verification done with RHEL10, RHEL9 & CentOS10 cluster deployment.

ocp4-upi-powervm: https://github.com/ocp-power-automation/ocp4-upi-powervm/pull/303
ocp4-playbooks: https://github.com/ocp-power-automation/ocp4-playbooks/pull/207

CC: @prb112 